### PR TITLE
realtime: fix message decoding

### DIFF
--- a/realtime/messages.go
+++ b/realtime/messages.go
@@ -179,13 +179,8 @@ func getMessagesFromUpdateEvent(update ddp.Update) []models.Message {
 		return make([]models.Message, 0)
 	}
 
-	messages := make([]models.Message, len(args))
-
-	for i, arg := range args {
-		messages[i] = *getMessageFromDocument(arg)
-	}
-
-	return messages
+	message := getMessageFromDocument(args[0])
+	return []models.Message{*message}
 }
 
 func getMessageFromData(data interface{}) *models.Message {


### PR DESCRIPTION
`update.args` contains `msg` and `options`. Not multiple messages.
`args[0]` is `msg`
`args[1]` is `options`

See https://github.com/RocketChat/Rocket.Chat/blob/6c3c3790c65a4de87f6b36f219fe2d6b6aad3c94/server/stream/messages.js#L27