### PR TITLE
Update channel subscription to match docs and fix doubles

### DIFF
--- a/realtime/channels.go
+++ b/realtime/channels.go
@@ -69,6 +69,7 @@ func (c *Client) GetChannelSubscriptions() ([]models.ChannelSubscription, error)
 	for _, sub := range channelSubs {
 		channelSubscription := models.ChannelSubscription{
 			ID:          stringOrZero(sub.Path("_id").Data()),
+			RoomId:      stringOrZero(sub.Path("rid").Data()),
 			Alert:       sub.Path("alert").Data().(bool),
 			Name:        stringOrZero(sub.Path("name").Data()),
 			DisplayName: stringOrZero(sub.Path("fname").Data()),

--- a/realtime/messages_test.go
+++ b/realtime/messages_test.go
@@ -12,9 +12,8 @@ func TestClient_SubscribeToMessageStream(t *testing.T) {
 
 	general := models.Channel{ID: "GENERAL"}
 	textToSend := "RealtimeTest"
-	messageChannel := make(chan models.Message, 1)
 
-	err := c.SubscribeToMessageStream(&general, messageChannel)
+	messageChannel, err := c.SubscribeToMessageStream(&general)
 
 	assert.Nil(t, err, "Function returned error")
 	assert.NotNil(t, messageChannel, "Function didn't returned general")
@@ -52,9 +51,8 @@ func TestClient_SubscribeToMessageStream_UnknownChannel(t *testing.T) {
 
 	c := getLoggedInClient(t)
 	channel := models.Channel{ID: "unknown"}
-	messageChannel := make(chan models.Message, 1)
 
-	err := c.SubscribeToMessageStream(&channel, messageChannel)
+	_, err := c.SubscribeToMessageStream(&channel)
 
 	assert.NotNil(t, err, "Function didn't return error")
 }


### PR DESCRIPTION
Currently update extractor does not match eventName (which is channel ID) so if you subscribe to two channel every message in either one will register in both channels.

Also documentation mentions returning channel, which would better agree with `Sub` function returning channel.