### PR TITLE
SendMessage with models.Message instead of string

### DIFF
--- a/realtime/messages.go
+++ b/realtime/messages.go
@@ -34,14 +34,9 @@ func (c *Client) LoadHistory(roomId string) error {
 // takes channel and message
 //
 // https://rocket.chat/docs/developer-guides/realtime-api/method-calls/send-message
-func (c *Client) SendMessage(channel *models.Channel, text string) (*models.Message, error) {
-	m := models.Message{
-		ID:     c.newRandomId(),
-		RoomID: channel.ID,
-		Msg:    text,
-	}
+func (c *Client) SendMessage(channel *models.Channel, msg models.Message) (*models.Message, error) {
 
-	rawResponse, err := c.ddp.Call("sendMessage", m)
+	rawResponse, err := c.ddp.Call("sendMessage", msg)
 	if err != nil {
 		return nil, err
 	}

--- a/realtime/messages_test.go
+++ b/realtime/messages_test.go
@@ -12,6 +12,11 @@ func TestClient_SubscribeToMessageStream(t *testing.T) {
 
 	general := models.Channel{ID: "GENERAL"}
 	textToSend := "RealtimeTest"
+	msg := models.Message{
+		ID:     c.newRandomId(),
+		RoomID: general.ID,
+		Msg:    textToSend,
+	}
 	messageChannel := make(chan models.Message, 1)
 
 	err := c.SubscribeToMessageStream(&general, messageChannel)
@@ -20,7 +25,7 @@ func TestClient_SubscribeToMessageStream(t *testing.T) {
 	assert.NotNil(t, messageChannel, "Function didn't returned general")
 
 	go func() {
-		sendAndAssertNoError(t, c, &general, textToSend)
+		sendAndAssertNoError(t, c, &general, msg)
 		// sendAndAssertNoError(t, c, &general, textToSend)
 		// sendAndAssertNoError(t, c, &general, textToSend)
 	}()
@@ -42,8 +47,8 @@ func assertMessage(t *testing.T, message models.Message) {
 	assert.NotNil(t, message.User.UserName, "Username was not set")
 }
 
-func sendAndAssertNoError(t *testing.T, c *Client, channel *models.Channel, text string) {
-	m, err := c.SendMessage(channel, text)
+func sendAndAssertNoError(t *testing.T, c *Client, channel *models.Channel, msg models.Message) {
+	m, err := c.SendMessage(channel, msg)
 	assert.Nil(t, err, "Error while sending message")
 	assert.NotNil(t, m, "SendMessage should return a Message object")
 }


### PR DESCRIPTION
Instead of passing a string to the SendMessage function, I pass a models.Message type variable. Passing a string really limits what we can do with the message.