### PR TITLE
Fix ActionButtonsAlignment name on json field

### DIFF
--- a/models/message.go
+++ b/models/message.go
@@ -63,7 +63,7 @@ type Attachment struct {
 	VideoURL string `json:"video_url,omitempty"`
 
 	Actions                []AttachmentAction               `json:"actions,omitempty"`
-	ActionButtonsAlignment AttachmentActionButtonsAlignment `json:"actionButtonsAlignment,omitempty"`
+	ActionButtonsAlignment AttachmentActionButtonsAlignment `json:"button_alignment,omitempty"`
 
 	Fields []AttachmentField `json:"fields,omitempty"`
 }


### PR DESCRIPTION
The field on the Apps-Engine is called `actionButtonsAlignment`, but in Rocket.Chat it's real name is `button_alignment`.

I've updated only the name of the field on the json, as I think that `ActionButtonsAlignment` is actually more descriptive than the name Rocket.Chat uses

@geekgonecrazy 