### PR TITLE
Added permissions.update function to rest api

### DIFF
--- a/models/user.go
+++ b/models/user.go
@@ -14,6 +14,7 @@ type CreateUserRequest struct {
 	Email        string            `json:"email"`
 	Password     string            `json:"password"`
 	Username     string            `json:"username"`
+	Roles        []string          `json:"roles,omitempty"`
 	CustomFields map[string]string `json:"customFields,omitempty"`
 }
 

--- a/rest/permissions.go
+++ b/rest/permissions.go
@@ -1,0 +1,32 @@
+package rest
+
+import (
+	"bytes"
+	"encoding/json"
+	"github.com/RocketChat/Rocket.Chat.Go.SDK/models"
+)
+
+type UpdatePermissionsRequest struct {
+	Permissions []models.Permission `json:"permissions"`
+}
+
+type UpdatePermissionsResponse struct {
+	Status
+	Permissions []models.Permission `json:"permissions"`
+}
+
+// UpdatePermissions updates permissions
+//
+// https://rocket.chat/docs/developer-guides/rest-api/permissions/update/
+func (c *Client) UpdatePermissions(req *UpdatePermissionsRequest) (*UpdatePermissionsResponse, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+
+	response := new(UpdatePermissionsResponse)
+	if err := c.Post("permissions.update", bytes.NewBuffer(body), response); err != nil {
+		return nil, err
+	}
+	return response, nil
+}

--- a/rest/permissions_test.go
+++ b/rest/permissions_test.go
@@ -1,0 +1,26 @@
+package rest
+
+import (
+	"github.com/RocketChat/Rocket.Chat.Go.SDK/common_testing"
+	"github.com/RocketChat/Rocket.Chat.Go.SDK/models"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestRocket_SetPermissions(t *testing.T) {
+	rocket := Client{Protocol: common_testing.Protocol, Host: common_testing.Host, Port: common_testing.Port}
+
+	err := rocket.Login(&models.UserCredentials{Email: "chat@catalysts.cc", Password: "test002"})
+	if err != nil {
+		t.Error(err)
+	}
+
+	request := UpdatePermissionsRequest{
+		Permissions: []models.Permission{{ID: "add-user-to-any-p-room", Roles: []string{"admin"}}},
+	}
+	response, err := rocket.UpdatePermissions(&request)
+
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+	assert.NotEmpty(t, response.Permissions)
+}

--- a/rest/permissions_test.go
+++ b/rest/permissions_test.go
@@ -7,18 +7,14 @@ import (
 	"testing"
 )
 
+// you have to set access-permissions on role "user" to run this test successfully!
 func TestRocket_SetPermissions(t *testing.T) {
-	rocket := Client{Protocol: common_testing.Protocol, Host: common_testing.Host, Port: common_testing.Port}
-
-	err := rocket.Login(&models.UserCredentials{Email: "chat@catalysts.cc", Password: "test002"})
-	if err != nil {
-		t.Error(err)
-	}
+	client := getAuthenticatedClient(t, common_testing.GetRandomString(), common_testing.GetRandomEmail(), common_testing.GetRandomString())
 
 	request := UpdatePermissionsRequest{
 		Permissions: []models.Permission{{ID: "add-user-to-any-p-room", Roles: []string{"admin"}}},
 	}
-	response, err := rocket.UpdatePermissions(&request)
+	response, err := client.UpdatePermissions(&request)
 
 	assert.Nil(t, err)
 	assert.NotNil(t, response)


### PR DESCRIPTION
Needed this to set permissions for a bot account using my own rocketchat-cli wrapper (no on github yet). 

Please merge so I can continue using your repo instead of my fork.
Thx! 