### PR TITLE
Improve the rest API by having the Pivate Group functions.

### DIFF
--- a/rest/channels.go
+++ b/rest/channels.go
@@ -19,6 +19,17 @@ type ChannelResponse struct {
 	Channel models.Channel `json:"channel"`
 }
 
+type GroupsResponse struct {
+	Status
+	models.Pagination
+	Groups []models.Channel `json:"groups"`
+}
+
+type GroupResponse struct {
+	Status
+	Group models.Channel `json:"group"`
+}
+
 // GetPublicChannels returns all channels that can be seen by the logged in user.
 //
 // https://rocket.chat/docs/developer-guides/rest-api/channels/list
@@ -30,6 +41,19 @@ func (c *Client) GetPublicChannels() (*ChannelsResponse, error) {
 
 	return response, nil
 }
+
+// GetPrivateGroups returns all channels that can be seen by the logged in user.
+//
+// https://rocket.chat/docs/developer-guides/rest-api/groups/list
+func (c *Client) GetPrivateGroups() (*GroupsResponse, error) {
+	response := new(GroupsResponse)
+	if err := c.Get("groups.list", nil, response); err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
 
 // GetJoinedChannels returns all channels that the user has joined.
 //
@@ -70,3 +94,20 @@ func (c *Client) GetChannelInfo(channel *models.Channel) (*models.Channel, error
 	return &response.Channel, nil
 }
 
+// GetGroupInfo get information about a group. That might be useful to update the usernames.
+//
+// https://rocket.chat/docs/developer-guides/rest-api/groups/info
+func (c *Client) GetGroupInfo(channel *models.Channel) (*models.Channel, error) {
+	response := new(GroupResponse)
+	switch {
+	case channel.Name != "" && channel.ID == "":
+		if err := c.Get("groups.info", url.Values{"roomName": []string{channel.Name}}, response); err != nil {
+			return nil, err
+		}
+	default:
+		if err := c.Get("groups.info", url.Values{"roomId": []string{channel.ID}}, response); err != nil {
+			return nil, err
+		}
+	}
+	return &response.Group, nil
+}


### PR DESCRIPTION
Added `(c *Client) GetPrivateGroups() (*GroupsResponse, error)` Retrieve a Private group.
Added `(c *Client) GetGroupInfo(channel *models.Channel) (*models.Channel, error)` Retrieve the groupinfo