### PR TITLE
include message type in Message model

### DIFF
--- a/models/message.go
+++ b/models/message.go
@@ -7,6 +7,7 @@ type Message struct {
 	RoomID   string `json:"rid"`
 	Msg      string `json:"msg"`
 	EditedBy string `json:"editedBy,omitempty"`
+	Type     string `json:"t,omitempty"`
 
 	Groupable bool `json:"groupable,omitempty"`
 

--- a/realtime/messages.go
+++ b/realtime/messages.go
@@ -234,6 +234,7 @@ func getMessageFromDocument(arg *gabs.Container) *models.Message {
 		ID:        stringOrZero(arg.Path("_id").Data()),
 		RoomID:    stringOrZero(arg.Path("rid").Data()),
 		Msg:       stringOrZero(arg.Path("msg").Data()),
+		Type:      stringOrZero(arg.Path("t").Data()),
 		Timestamp: ts,
 		User: &models.User{
 			ID:       stringOrZero(arg.Path("u._id").Data()),


### PR DESCRIPTION
Unfortunately the feature is not documented here: https://rocket.chat/docs/developer-guides/realtime-api/the-message-object/

But the "t" field includes the type of the message (e.g. `subscription-role-added`, `subscription-role-removed`, `ul` (for a user leaving), `uj` (for a user joining) etc.)