### PR TITLE
Make random id more random

### DIFF
--- a/realtime/client.go
+++ b/realtime/client.go
@@ -93,5 +93,5 @@ func (c *Client) Close() {
 
 // Some of the rocketchat objects need unique IDs specified by the client
 func (c *Client) newRandomId() string {
-	return fmt.Sprintf("%f", rand.Float64())
+	return fmt.Sprintf("%x%x", rand.Uint64(), time.Now().UTC().UnixNano())
 }


### PR DESCRIPTION
Quick fix of the generated random message id, the chances of the current being the same as previous ones are very high.
Somewhat fixes #40 