### PR TITLE
Use per client messageListenerAdded flag

### DIFF
--- a/realtime/client.go
+++ b/realtime/client.go
@@ -13,8 +13,9 @@ import (
 )
 
 type Client struct {
-	ddp *ddp.Client
-	sf  *sonyflake.Sonyflake
+	ddp                  *ddp.Client
+	sf                   *sonyflake.Sonyflake
+	messageListenerAdded bool
 }
 
 //NewClient creates a new instance and connects to the websocket.

--- a/realtime/messages.go
+++ b/realtime/messages.go
@@ -17,8 +17,6 @@ const (
 	default_buffer_size = 100
 )
 
-var messageListenerAdded = false
-
 // NewMessage creates basic message with an ID, a RoomID, and a Msg
 // Takes channel and text
 func (c *Client) NewMessage(channel *models.Channel, text string) *models.Message {
@@ -189,9 +187,9 @@ func (c *Client) SubscribeToMessageStream(channel *models.Channel, msgChannel ch
 		return err
 	}
 
-	if !messageListenerAdded {
+	if !c.messageListenerAdded {
 		c.ddp.CollectionByName("stream-room-messages").AddUpdateListener(messageExtractor{msgChannel, "update"})
-		messageListenerAdded = true
+		c.messageListenerAdded = true
 	}
 
 	return nil
@@ -203,9 +201,9 @@ func (c *Client) SubscribeToMyMessages(msgChannel chan models.Message) error {
 		return err
 	}
 
-	if !messageListenerAdded {
+	if !c.messageListenerAdded {
 		c.ddp.CollectionByName("stream-room-messages").AddUpdateListener(messageExtractor{msgChannel, "update"})
-		messageListenerAdded = true
+		c.messageListenerAdded = true
 	}
 
 	return nil
@@ -262,11 +260,11 @@ func stringOrZero(i interface{}) string {
 		return ""
 	}
 
-	switch i.(type) {
+	switch v := i.(type) {
 	case string:
-		return i.(string)
+		return v
 	case float64:
-		return fmt.Sprintf("%f", i.(float64))
+		return fmt.Sprintf("%f", v)
 	default:
 		return ""
 	}


### PR DESCRIPTION
original changes by @patrick246.

This makes the messageListenerAdded flag per client so that multiple clients don't interfere with each other.