### PR TITLE
Remove deprecated /v1/info endpoint

### DIFF
--- a/rest/information.go
+++ b/rest/information.go
@@ -6,24 +6,6 @@ import (
 	"github.com/RocketChat/Rocket.Chat.Go.SDK/models"
 )
 
-type InfoResponse struct {
-	Status
-	Info models.Info `json:"info"`
-}
-
-// GetServerInfo a simple method, requires no authentication,
-// that returns information about the server including version information.
-//
-// https://rocket.chat/docs/developer-guides/rest-api/miscellaneous/info
-func (c *Client) GetServerInfo() (*models.Info, error) {
-	response := new(InfoResponse)
-	if err := c.Get("info", nil, response); err != nil {
-		return nil, err
-	}
-
-	return &response.Info, nil
-}
-
 type DirectoryResponse struct {
 	Status
 	models.Directory

--- a/rest/information_test.go
+++ b/rest/information_test.go
@@ -8,16 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRocket_GetServerInfo(t *testing.T) {
-	rocket := Client{Protocol: common_testing.Protocol, Host: common_testing.Host, Port: common_testing.Port}
-
-	info, err := rocket.GetServerInfo()
-
-	assert.Nil(t, err)
-	assert.NotNil(t, info)
-	assert.NotEmpty(t, info.Version)
-}
-
 func TestRocket_GetDirectory(t *testing.T) {
 	rocket := getDefaultClient(t)
 


### PR DESCRIPTION
The endpoint /v1/info was deprecated in v1.0.0 and removed in v1.12.0 (https://developer.rocket.chat/reference/api/deprecation)

This request removes the method to call this endpoint as well as the test for this method.