### PR TITLE
Modify Permission struct to omit field if empty

### DIFF
--- a/models/permission.go
+++ b/models/permission.go
@@ -2,6 +2,6 @@ package models
 
 type Permission struct {
 	ID        string   `json:"_id"`
-	UpdatedAt string   `json:"_updatedAt.$date"`
+	UpdatedAt string   `json:"_updatedAt.$date,omitempty"`
 	Roles     []string `json:"roles"`
 }

--- a/rest/permissions_test.go
+++ b/rest/permissions_test.go
@@ -1,10 +1,11 @@
 package rest
 
 import (
+	"testing"
+
 	"github.com/RocketChat/Rocket.Chat.Go.SDK/common_testing"
 	"github.com/RocketChat/Rocket.Chat.Go.SDK/models"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 // you have to set access-permissions on role "user" to run this test successfully!


### PR DESCRIPTION
Before this change, the `Client.UpdatePermissions` method returned a bad response (Error: Invalid body params)

This simple change to omit the `UpdatedAt` field in the `Permission` struct fixes the request parameters. The `SetPermissions` test now passes.