### PR TITLE
Update package doc strings with working URLs

### DIFF
--- a/rest/channels.go
+++ b/rest/channels.go
@@ -30,9 +30,9 @@ type GroupResponse struct {
 	Group models.Channel `json:"group"`
 }
 
-// GetPublicChannels returns all channels that can be seen by the logged in user.
+// GetPublicChannels lists all of the channels on the server.
 //
-// https://rocket.chat/docs/developer-guides/rest-api/channels/list
+// https://developer.rocket.chat/reference/api/rest-api/endpoints/team-collaboration-endpoints/channels-endpoints/list
 func (c *Client) GetPublicChannels() (*ChannelsResponse, error) {
 	response := new(ChannelsResponse)
 	if err := c.Get("channels.list", nil, response); err != nil {
@@ -42,9 +42,9 @@ func (c *Client) GetPublicChannels() (*ChannelsResponse, error) {
 	return response, nil
 }
 
-// GetPrivateGroups returns all channels that can be seen by the logged in user.
+// GetPrivateGroups lists all of the private groups the calling user has joined.
 //
-// https://rocket.chat/docs/developer-guides/rest-api/groups/list
+// https://developer.rocket.chat/reference/api/rest-api/endpoints/team-collaboration-endpoints/groups-endpoints/list
 func (c *Client) GetPrivateGroups() (*GroupsResponse, error) {
 	response := new(GroupsResponse)
 	if err := c.Get("groups.list", nil, response); err != nil {
@@ -54,9 +54,9 @@ func (c *Client) GetPrivateGroups() (*GroupsResponse, error) {
 	return response, nil
 }
 
-// GetJoinedChannels returns all channels that the user has joined.
+// GetJoinedChannels lists all of the channels the calling user has joined.
 //
-// https://rocket.chat/docs/developer-guides/rest-api/channels/list-joined
+// https://developer.rocket.chat/reference/api/rest-api/endpoints/team-collaboration-endpoints/channels-endpoints/list-joined
 func (c *Client) GetJoinedChannels(params url.Values) (*ChannelsResponse, error) {
 	response := new(ChannelsResponse)
 	if err := c.Get("channels.list.joined", params, response); err != nil {
@@ -66,17 +66,18 @@ func (c *Client) GetJoinedChannels(params url.Values) (*ChannelsResponse, error)
 	return response, nil
 }
 
-// LeaveChannel leaves a channel. The id of the channel has to be not nil.
+// LeaveChannel causes the callee to be removed from the channel.
+// The id of the channel must not be nil.
 //
-// https://rocket.chat/docs/developer-guides/rest-api/channels/leave
+// https://developer.rocket.chat/reference/api/rest-api/endpoints/team-collaboration-endpoints/channels-endpoints/leave
 func (c *Client) LeaveChannel(channel *models.Channel) error {
 	var body = fmt.Sprintf(`{ "roomId": "%s"}`, channel.ID)
 	return c.Post("channels.leave", bytes.NewBufferString(body), new(ChannelResponse))
 }
 
-// GetChannelInfo get information about a channel. That might be useful to update the usernames.
+// GetChannelInfo retrieves the information about the channel.
 //
-// https://rocket.chat/docs/developer-guides/rest-api/channels/info
+// https://developer.rocket.chat/reference/api/rest-api/endpoints/team-collaboration-endpoints/channels-endpoints/info
 func (c *Client) GetChannelInfo(channel *models.Channel) (*models.Channel, error) {
 	response := new(ChannelResponse)
 	switch {
@@ -93,9 +94,9 @@ func (c *Client) GetChannelInfo(channel *models.Channel) (*models.Channel, error
 	return &response.Channel, nil
 }
 
-// GetGroupInfo get information about a group. That might be useful to update the usernames.
+// GetGroupInfo retrieves the information about the private group, only if you're part of the group.
 //
-// https://rocket.chat/docs/developer-guides/rest-api/groups/info
+// https://developer.rocket.chat/reference/api/rest-api/endpoints/team-collaboration-endpoints/groups-endpoints/info
 func (c *Client) GetGroupInfo(channel *models.Channel) (*models.Channel, error) {
 	response := new(GroupResponse)
 	switch {

--- a/rest/im.go
+++ b/rest/im.go
@@ -14,13 +14,13 @@ type DirectMessageResponse struct {
 type Room struct {
 	ID        string   `json:"_id"`
 	Rid       string   `json:"rid"`
-	Type         string   `json:"t"`
+	Type      string   `json:"t"`
 	Usernames []string `json:"usernames"`
 }
 
-// Creates a DirectMessage
+// CreateDirectMessage creates a direct message session with another user.
 //
-// https://developer.rocket.chat/api/rest-api/methods/im/create
+// https://developer.rocket.chat/reference/api/rest-api/endpoints/team-collaboration-endpoints/im-endpoints/create
 func (c *Client) CreateDirectMessage(username string) (*Room, error) {
 	body := fmt.Sprintf(`{ "username": "%s" }`, username)
 	resp := new(DirectMessageResponse)

--- a/rest/information.go
+++ b/rest/information.go
@@ -32,7 +32,7 @@ type DirectoryResponse struct {
 // GetDirectory a method, that searches by users or channels on all users and channels available on server.
 // It supports the Offset, Count, and Sort Query Parameters along with Query and Fields Query Parameters.
 //
-// https://rocket.chat/docs/developer-guides/rest-api/miscellaneous/directory
+// https://developer.rocket.chat/reference/api/rest-api/endpoints/team-collaboration-endpoints/miscellaneous-endpoints/directory
 func (c *Client) GetDirectory(params url.Values) (*models.Directory, error) {
 	response := new(DirectoryResponse)
 	if err := c.Get("directory", params, response); err != nil {
@@ -50,7 +50,7 @@ type SpotlightResponse struct {
 // GetSpotlight searches for users or rooms that are visible to the user.
 // WARNING: It will only return rooms that user didn’t join yet.
 //
-// https://rocket.chat/docs/developer-guides/rest-api/miscellaneous/spotlight
+// https://developer.rocket.chat/reference/api/rest-api/endpoints/team-collaboration-endpoints/miscellaneous-endpoints/spotlight
 func (c *Client) GetSpotlight(params url.Values) (*models.Spotlight, error) {
 	response := new(SpotlightResponse)
 	if err := c.Get("spotlight", params, response); err != nil {
@@ -65,8 +65,7 @@ type StatisticsResponse struct {
 	models.StatisticsInfo
 }
 
-// GetStatistics
-// Statistics about the Rocket.Chat server.
+// GetStatistics returns statistics about the Rocket.Chat server.
 //
 // https://rocket.chat/docs/developer-guides/rest-api/miscellaneous/statistics
 func (c *Client) GetStatistics() (*models.StatisticsInfo, error) {
@@ -83,11 +82,11 @@ type StatisticsListResponse struct {
 	models.StatisticsList
 }
 
-// GetStatisticsList
-// Selectable statistics about the Rocket.Chat server.
+// GetStatisticsList returns selectable statistics about the Rocket.Chat server.
 // It supports the Offset, Count and Sort Query Parameters along with just the Fields and Query Parameters.
+// Requires view-statistics permission.
 //
-// https://rocket.chat/docs/developer-guides/rest-api/miscellaneous/statistics.list
+// https://developer.rocket.chat/reference/api/rest-api/endpoints/team-collaboration-endpoints/miscellaneous-endpoints/statistics-list
 func (c *Client) GetStatisticsList(params url.Values) (*models.StatisticsList, error) {
 	response := new(StatisticsListResponse)
 	if err := c.Get("statistics.list", params, response); err != nil {

--- a/rest/messages.go
+++ b/rest/messages.go
@@ -30,10 +30,10 @@ func (c *Client) Send(channel *models.Channel, msg string) error {
 	return c.Post("chat.postMessage", bytes.NewBufferString(body), new(MessageResponse))
 }
 
-// PostMessage send a message to a channel. The channel or roomId has to be not nil.
-// The message will be json encode.
+// PostMessage sends a message to a channel. The channel or roomId has to be not nil.
+// The message will be json encoded.
 //
-// https://rocket.chat/docs/developer-guides/rest-api/chat/postmessage
+// https://developer.rocket.chat/reference/api/rest-api/endpoints/team-collaboration-endpoints/chat-endpoints/postmessage
 func (c *Client) PostMessage(msg *models.PostMessage) (*MessageResponse, error) {
 	body, err := json.Marshal(msg)
 	if err != nil {
@@ -45,10 +45,10 @@ func (c *Client) PostMessage(msg *models.PostMessage) (*MessageResponse, error) 
 	return response, err
 }
 
-// Get messages from a channel. The channel id has to be not nil. Optionally a
-// count can be specified to limit the size of the returned messages.
+// GetMessages retrieves the messages from a channel. The channel id has to be not nil.
+// Optionally count and offset can be specified to limit the size and start of the returned messages.
 //
-// https://rocket.chat/docs/developer-guides/rest-api/channels/history
+// https://developer.rocket.chat/reference/api/rest-api/endpoints/team-collaboration-endpoints/channels-endpoints/history
 func (c *Client) GetMessages(channel *models.Channel, page *models.Pagination) ([]models.Message, error) {
 	params := url.Values{
 		"roomId": []string{channel.ID},

--- a/rest/permissions.go
+++ b/rest/permissions.go
@@ -3,6 +3,7 @@ package rest
 import (
 	"bytes"
 	"encoding/json"
+
 	"github.com/RocketChat/Rocket.Chat.Go.SDK/models"
 )
 
@@ -15,9 +16,9 @@ type UpdatePermissionsResponse struct {
 	Permissions []models.Permission `json:"permissions"`
 }
 
-// UpdatePermissions updates permissions
+// UpdatePermissions edits permissions on the server.
 //
-// https://rocket.chat/docs/developer-guides/rest-api/permissions/update/
+// https://developer.rocket.chat/reference/api/rest-api/endpoints/team-collaboration-endpoints/permissions-endpoints/update-permissions
 func (c *Client) UpdatePermissions(req *UpdatePermissionsRequest) (*UpdatePermissionsResponse, error) {
 	body, err := json.Marshal(req)
 	if err != nil {


### PR DESCRIPTION
All of the reference URLs in the comments currently point to web pages that no longer exist. This pull request is focused on updating these URLs to point to current API reference pages. Currently only the rest package docs have been updated.

Additionally, this request does some minor housekeeping including:
 1. Update some method comments to better reflect the wording on API reference pages.
 2. Rearrange some methods for more logical grouping.
 3. Refactor `CreateUserResponse` struct for readability.
