### PR TITLE
Add methods to expand coverage of `chat` endpoints

### DIFF
--- a/models/message.go
+++ b/models/message.go
@@ -25,6 +25,15 @@ type Message struct {
 	// SandstormSessionID interface{} `json:"sandstormSessionId"`
 }
 
+// DeleteMessage is payload for chat.delete endpoint
+//
+// https://developer.rocket.chat/reference/api/rest-api/endpoints/core-endpoints/chat-endpoints/delete
+type DeleteMessage struct {
+	RoomID string `json:"roomId"`
+	MsgID  string `json:"msgId"`
+	AsUser bool   `json:"asUser"`
+}
+
 // PostMessage Payload for postmessage rest API
 //
 // https://rocket.chat/docs/developer-guides/rest-api/chat/postmessage/

--- a/models/message.go
+++ b/models/message.go
@@ -25,6 +25,15 @@ type Message struct {
 	// SandstormSessionID interface{} `json:"sandstormSessionId"`
 }
 
+// UpdateMessage is payload for chat.update
+//
+// https://developer.rocket.chat/reference/api/rest-api/endpoints/core-endpoints/chat-endpoints/message-update
+type UpdateMessage struct {
+	RoomID string `json:"roomId"`
+	MsgID  string `json:"msgId"`
+	Text   string `json:"text"`
+}
+
 // DeleteMessage is payload for chat.delete endpoint
 //
 // https://developer.rocket.chat/reference/api/rest-api/endpoints/core-endpoints/chat-endpoints/delete

--- a/rest/messages.go
+++ b/rest/messages.go
@@ -77,10 +77,33 @@ func (c *Client) GetMessages(channel *models.Channel, page *models.Pagination) (
 
 	if page != nil {
 		params.Add("count", strconv.Itoa(page.Count))
+		params.Add("offset", strconv.Itoa(page.Offset))
 	}
 
 	response := new(MessagesResponse)
 	if err := c.Get("channels.history", params, response); err != nil {
+		return nil, err
+	}
+
+	return response.Messages, nil
+}
+
+// GetMentionedMessages retrieves mentioned messages.
+// It supports the Offset and Count Query Parameters.
+//
+// https://developer.rocket.chat/reference/api/rest-api/endpoints/core-endpoints/chat-endpoints/getmentionedmessages
+func (c *Client) GetMentionedMessages(channel *models.Channel, page *models.Pagination) ([]models.Message, error) {
+	params := url.Values{
+		"roomId": []string{channel.ID},
+	}
+
+	if page != nil {
+		params.Add("count", strconv.Itoa(page.Count))
+		params.Add("offset", strconv.Itoa(page.Offset))
+	}
+
+	response := new(MessagesResponse)
+	if err := c.Get("chat.getMentionedMessages", params, response); err != nil {
 		return nil, err
 	}
 
@@ -114,4 +137,20 @@ func (c *Client) DeleteMessage(msg *models.DeleteMessage) (*DeleteMessageRespons
 	response := new(DeleteMessageResponse)
 	err = c.Post("chat.delete", bytes.NewBuffer(body), response)
 	return response, err
+}
+
+// SearchMessages searches for messages in a channel by id and text message
+//
+// https://developer.rocket.chat/reference/api/rest-api/endpoints/core-endpoints/chat-endpoints/search-message
+
+func (c *Client) SearchMessages(channel *models.Channel, searchText string) ([]models.Message, error) {
+	params := url.Values{
+		"roomId":     []string{channel.ID},
+		"searchText": []string{searchText},
+	}
+	response := new(MessagesResponse)
+	if err := c.Get("chat.search", params, response); err != nil {
+		return nil, err
+	}
+	return response.Messages, nil
 }

--- a/rest/messages.go
+++ b/rest/messages.go
@@ -87,6 +87,21 @@ func (c *Client) GetMessages(channel *models.Channel, page *models.Pagination) (
 	return response.Messages, nil
 }
 
+// UpdateMessage updates a specific message.
+//
+// https://developer.rocket.chat/reference/api/rest-api/endpoints/core-endpoints/chat-endpoints/message-update
+func (c *Client) UpdateMessage(msg *models.UpdateMessage) (*MessageResponse, error) {
+	body, err := json.Marshal(msg)
+	if err != nil {
+		return nil, err
+	}
+
+	response := new(MessageResponse)
+	err = c.Post("chat.update", bytes.NewBuffer(body), response)
+	return response, err
+
+}
+
 // DeleteMessage deletes a specific message.
 //
 // https://developer.rocket.chat/reference/api/rest-api/endpoints/core-endpoints/chat-endpoints/delete

--- a/rest/messages_test.go
+++ b/rest/messages_test.go
@@ -35,9 +35,34 @@ func TestRocket_GetMessage(t *testing.T) {
 	assert.Equal(t, text, msg.Msg)
 }
 
+func TestRocket_UpdateUser(t *testing.T) {
+	rocket := getDefaultClient(t)
+	textOriginal := "TestRocket_UpdateMessageOriginal"
+	textUpdated := "TestRocket_UpdateMessageUpdated"
+	postMessage := &models.PostMessage{
+		Channel: "general",
+		Text:    textOriginal,
+	}
+	postResp, err := rocket.PostMessage(postMessage)
+	assert.Nil(t, err)
+	assert.NotNil(t, postResp)
+
+	roomId := postResp.Message.RoomID
+	msgId := postResp.Message.ID
+	updateMessage := &models.UpdateMessage{
+		RoomID: roomId,
+		MsgID:  msgId,
+		Text:   textUpdated,
+	}
+	resp, err := rocket.UpdateMessage(updateMessage)
+	assert.Nil(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, textUpdated, resp.Message.Msg)
+}
+
 func TestRocket_DeleteMessage(t *testing.T) {
 	rocket := getDefaultClient(t)
-	t.Run("asUser", func(t *testing.T) {
+	t.Run("asUser = true", func(t *testing.T) {
 		text := "TestRocket_DeleteMessageAsUser"
 		postMessage := &models.PostMessage{
 			Channel: "general",
@@ -53,6 +78,27 @@ func TestRocket_DeleteMessage(t *testing.T) {
 			RoomID: roomId,
 			MsgID:  msgId,
 			AsUser: true,
+		}
+		resp, err := rocket.DeleteMessage(deleteMessage)
+		assert.Nil(t, err)
+		assert.NotNil(t, resp)
+	})
+	t.Run("asUser = false", func(t *testing.T) {
+		text := "TestRocket_DeleteMessageNotAsUser"
+		postMessage := &models.PostMessage{
+			Channel: "general",
+			Text:    text,
+		}
+		postResp, err := rocket.PostMessage(postMessage)
+		assert.Nil(t, err)
+		assert.NotNil(t, postResp)
+
+		roomId := postResp.Message.RoomID
+		msgId := postResp.Message.ID
+		deleteMessage := &models.DeleteMessage{
+			RoomID: roomId,
+			MsgID:  msgId,
+			AsUser: false,
 		}
 		resp, err := rocket.DeleteMessage(deleteMessage)
 		assert.Nil(t, err)

--- a/rest/messages_test.go
+++ b/rest/messages_test.go
@@ -7,6 +7,59 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestRocket_PostMessage(t *testing.T) {
+	rocket := getDefaultClient(t)
+	postMessage := &models.PostMessage{
+		Channel: "general",
+		Text:    "TestRocket_PostMessage",
+	}
+	resp, err := rocket.PostMessage(postMessage)
+	assert.Nil(t, err)
+	assert.NotNil(t, resp)
+}
+
+func TestRocket_GetMessage(t *testing.T) {
+	rocket := getDefaultClient(t)
+	text := "TestRocket_GetMessage"
+	postMessage := &models.PostMessage{
+		Channel: "general",
+		Text:    text,
+	}
+	postResp, err := rocket.PostMessage(postMessage)
+	assert.Nil(t, err)
+	assert.NotNil(t, postResp)
+
+	msgId := postResp.Message.ID
+	msg, err := rocket.GetMessage(msgId)
+	assert.Nil(t, err)
+	assert.Equal(t, text, msg.Msg)
+}
+
+func TestRocket_DeleteMessage(t *testing.T) {
+	rocket := getDefaultClient(t)
+	t.Run("asUser", func(t *testing.T) {
+		text := "TestRocket_DeleteMessageAsUser"
+		postMessage := &models.PostMessage{
+			Channel: "general",
+			Text:    text,
+		}
+		postResp, err := rocket.PostMessage(postMessage)
+		assert.Nil(t, err)
+		assert.NotNil(t, postResp)
+
+		roomId := postResp.Message.RoomID
+		msgId := postResp.Message.ID
+		deleteMessage := &models.DeleteMessage{
+			RoomID: roomId,
+			MsgID:  msgId,
+			AsUser: true,
+		}
+		resp, err := rocket.DeleteMessage(deleteMessage)
+		assert.Nil(t, err)
+		assert.NotNil(t, resp)
+	})
+}
+
 func TestRocket_SendAndReceive(t *testing.T) {
 	rocket := getDefaultClient(t)
 	general := &models.Channel{ID: "GENERAL", Name: "general"}


### PR DESCRIPTION
This PR adds methods and tests to cover the following endpoints:

- [x] `chat.getMessage`
- [x] `chat.getMentionedMessages`
- [x] `chat.delete`
- [x] `chat.update`
- [x] `chat.search`