### PR TITLE
Add methods to expand coverage of `channels` endpoints

### DIFF
--- a/rest/channels.go
+++ b/rest/channels.go
@@ -20,7 +20,7 @@ type ChannelResponse struct {
 	Channel models.Channel `json:"channel"`
 }
 
-type ChannelMembersResponse struct {
+type channelMembersResponse struct {
 	Status
 	models.Pagination
 	Members []*models.User `json:"members"`
@@ -157,7 +157,7 @@ func (c *Client) JoinChannel(channel *models.Channel, joinCode string) (*models.
 //
 // https://developer.rocket.chat/reference/api/rest-api/endpoints/core-endpoints/channels-endpoints/members
 func (c *Client) GetChannelMembers(channel *models.Channel) ([]*models.User, error) {
-	response := new(ChannelMembersResponse)
+	response := new(channelMembersResponse)
 	switch {
 	case channel.Name != "" && channel.ID == "":
 		if err := c.Get("channels.members", url.Values{"roomName": []string{channel.Name}}, response); err != nil {

--- a/rest/channels.go
+++ b/rest/channels.go
@@ -19,35 +19,12 @@ type ChannelResponse struct {
 	Channel models.Channel `json:"channel"`
 }
 
-type GroupsResponse struct {
-	Status
-	models.Pagination
-	Groups []models.Channel `json:"groups"`
-}
-
-type GroupResponse struct {
-	Status
-	Group models.Channel `json:"group"`
-}
-
 // GetPublicChannels returns all channels that can be seen by the logged in user.
 //
 // https://rocket.chat/docs/developer-guides/rest-api/channels/list
 func (c *Client) GetPublicChannels() (*ChannelsResponse, error) {
 	response := new(ChannelsResponse)
 	if err := c.Get("channels.list", nil, response); err != nil {
-		return nil, err
-	}
-
-	return response, nil
-}
-
-// GetPrivateGroups returns all channels that can be seen by the logged in user.
-//
-// https://rocket.chat/docs/developer-guides/rest-api/groups/list
-func (c *Client) GetPrivateGroups() (*GroupsResponse, error) {
-	response := new(GroupsResponse)
-	if err := c.Get("groups.list", nil, response); err != nil {
 		return nil, err
 	}
 
@@ -91,22 +68,4 @@ func (c *Client) GetChannelInfo(channel *models.Channel) (*models.Channel, error
 	}
 
 	return &response.Channel, nil
-}
-
-// GetGroupInfo get information about a group. That might be useful to update the usernames.
-//
-// https://rocket.chat/docs/developer-guides/rest-api/groups/info
-func (c *Client) GetGroupInfo(channel *models.Channel) (*models.Channel, error) {
-	response := new(GroupResponse)
-	switch {
-	case channel.Name != "" && channel.ID == "":
-		if err := c.Get("groups.info", url.Values{"roomName": []string{channel.Name}}, response); err != nil {
-			return nil, err
-		}
-	default:
-		if err := c.Get("groups.info", url.Values{"roomId": []string{channel.ID}}, response); err != nil {
-			return nil, err
-		}
-	}
-	return &response.Group, nil
 }

--- a/rest/channels.go
+++ b/rest/channels.go
@@ -2,6 +2,7 @@ package rest
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/url"
 
@@ -19,8 +20,18 @@ type ChannelResponse struct {
 	Channel models.Channel `json:"channel"`
 }
 
+// CreateChannel is payload for channels.create
+//
+// https://developer.rocket.chat/reference/api/rest-api/endpoints/core-endpoints/channels-endpoints/create
+type CreateChannel struct {
+	ChannelName string   `json:"name"`
+	Members     []string `json:"members"`
+	ReadOnly    bool     `json:"readOnly"`
+}
+
 // GetPublicChannels returns all channels that can be seen by the logged in user.
 //
+
 // https://rocket.chat/docs/developer-guides/rest-api/channels/list
 func (c *Client) GetPublicChannels() (*ChannelsResponse, error) {
 	response := new(ChannelsResponse)
@@ -68,4 +79,19 @@ func (c *Client) GetChannelInfo(channel *models.Channel) (*models.Channel, error
 	}
 
 	return &response.Channel, nil
+}
+
+// CreateChannel creates a new public channel, optionally including specified users.
+// The channel creator is always included.
+//
+// https://developer.rocket.chat/reference/api/rest-api/endpoints/core-endpoints/channels-endpoints/create
+func (c *Client) CreateChannel(channel *CreateChannel) (*ChannelResponse, error) {
+	body, err := json.Marshal(channel)
+	if err != nil {
+		return nil, err
+	}
+
+	response := new(ChannelResponse)
+	err = c.Post("channels.create", bytes.NewBuffer(body), response)
+	return response, err
 }

--- a/rest/channels.go
+++ b/rest/channels.go
@@ -29,7 +29,7 @@ type ChannelMembersResponse struct {
 // CreateChannel is payload for channels.create
 //
 // https://developer.rocket.chat/reference/api/rest-api/endpoints/core-endpoints/channels-endpoints/create
-type CreateChannel struct {
+type createChannel struct {
 	ChannelName string   `json:"name"`
 	Members     []string `json:"members"`
 	ReadOnly    bool     `json:"readOnly"`
@@ -101,12 +101,16 @@ func (c *Client) GetChannelInfo(channel *models.Channel) (*models.Channel, error
 // The channel creator is always included.
 //
 // https://developer.rocket.chat/reference/api/rest-api/endpoints/core-endpoints/channels-endpoints/create
-func (c *Client) CreateChannel(channel *CreateChannel) (*models.Channel, error) {
-	body, err := json.Marshal(channel)
+func (c *Client) CreateChannel(channelName string, users []*models.User, readOnly bool) (*models.Channel, error) {
+	var usernames []string
+	for _, user := range users {
+		usernames = append(usernames, user.Name)
+	}
+	createChannel := &createChannel{ChannelName: channelName, Members: usernames, ReadOnly: readOnly}
+	body, err := json.Marshal(createChannel)
 	if err != nil {
 		return nil, err
 	}
-
 	response := new(ChannelResponse)
 	err = c.Post("channels.create", bytes.NewBuffer(body), response)
 

--- a/rest/channels.go
+++ b/rest/channels.go
@@ -29,9 +29,14 @@ type CreateChannel struct {
 	ReadOnly    bool     `json:"readOnly"`
 }
 
-type channelInvite struct {
+type inviteChannel struct {
 	RoomId  string   `json:"roomId"`
 	UserIds []string `json:"userIds"`
+}
+
+type joinChannel struct {
+	RoomId   string `json:"roomId"`
+	JoinCode string `json:"joinCode,omitempty"`
 }
 
 // GetPublicChannels returns all channels that can be seen by the logged in user.
@@ -109,7 +114,7 @@ func (c *Client) InviteChannel(channel *models.Channel, users []*models.User) (*
 	for _, user := range users {
 		ids = append(ids, user.ID)
 	}
-	invite := &channelInvite{RoomId: channel.ID, UserIds: ids}
+	invite := &inviteChannel{RoomId: channel.ID, UserIds: ids}
 	body, err := json.Marshal(invite)
 	if err != nil {
 		return nil, err
@@ -117,5 +122,22 @@ func (c *Client) InviteChannel(channel *models.Channel, users []*models.User) (*
 
 	response := new(ChannelResponse)
 	err = c.Post("channels.invite", bytes.NewBuffer(body), response)
+	return response, err
+}
+
+// JoinChannel joins yourself to the channel.
+// joinCode isn't needed if the user has the permission "join-without-join-code"
+// An empty string should be passed if not required
+//
+// https://developer.rocket.chat/reference/api/rest-api/endpoints/core-endpoints/channels-endpoints/join
+func (c *Client) JoinChannel(channel *models.Channel, joinCode string) (*ChannelResponse, error) {
+	join := &joinChannel{RoomId: channel.ID}
+	body, err := json.Marshal(join)
+	if err != nil {
+		return nil, err
+	}
+
+	response := new(ChannelResponse)
+	err = c.Post("channels.join", bytes.NewBuffer(body), response)
 	return response, err
 }

--- a/rest/channels.go
+++ b/rest/channels.go
@@ -29,6 +29,11 @@ type CreateChannel struct {
 	ReadOnly    bool     `json:"readOnly"`
 }
 
+type channelInvite struct {
+	RoomId  string   `json:"roomId"`
+	UserIds []string `json:"userIds"`
+}
+
 // GetPublicChannels returns all channels that can be seen by the logged in user.
 //
 
@@ -93,5 +98,24 @@ func (c *Client) CreateChannel(channel *CreateChannel) (*ChannelResponse, error)
 
 	response := new(ChannelResponse)
 	err = c.Post("channels.create", bytes.NewBuffer(body), response)
+	return response, err
+}
+
+// InviteChannel adds users to the channel.
+//
+// https://developer.rocket.chat/reference/api/rest-api/endpoints/core-endpoints/channels-endpoints/invite
+func (c *Client) InviteChannel(channel *models.Channel, users []*models.User) (*ChannelResponse, error) {
+	var ids []string
+	for _, user := range users {
+		ids = append(ids, user.ID)
+	}
+	invite := &channelInvite{RoomId: channel.ID, UserIds: ids}
+	body, err := json.Marshal(invite)
+	if err != nil {
+		return nil, err
+	}
+
+	response := new(ChannelResponse)
+	err = c.Post("channels.invite", bytes.NewBuffer(body), response)
 	return response, err
 }

--- a/rest/channels_test.go
+++ b/rest/channels_test.go
@@ -69,8 +69,26 @@ func TestRocket_InviteChannel(t *testing.T) {
 
 func TestRocket_JoinChannel(t *testing.T) {
 	rocket := getDefaultClient(t)
-
 	general := &models.Channel{ID: "GENERAL"}
 	_, err := rocket.JoinChannel(general, "")
 	assert.Nil(t, err)
+}
+
+func TestRocket_GetChannelMembers(t *testing.T) {
+	rocket := getDefaultClient(t)
+	t.Run("With channel name", func(t *testing.T) {
+		general := &models.Channel{Name: "general"}
+		members, err := rocket.GetChannelMembers(general)
+		assert.Nil(t, err)
+		// are new users added to general by default?
+		assert.GreaterOrEqual(t, len(members), 1)
+
+	})
+	t.Run("With channel ID", func(t *testing.T) {
+		general := &models.Channel{ID: "GENERAL"}
+		members, err := rocket.GetChannelMembers(general)
+		assert.Nil(t, err)
+		assert.GreaterOrEqual(t, len(members), 1)
+	})
+
 }

--- a/rest/channels_test.go
+++ b/rest/channels_test.go
@@ -58,16 +58,19 @@ func TestRocket_CreateChannel(t *testing.T) {
 func TestRocket_InviteChannel(t *testing.T) {
 	rocket := getDefaultClient(t)
 
-	// channel := &CreateChannel{ChannelName: "GENERAL"}
-	// resp, err := rocket.CreateChannel(channel)
-	// assert.Nil(t, err)
-
 	general := &models.Channel{ID: "GENERAL"}
-	// needs users.info to get userID
 	user, err := rocket.UserInfo(testUserName)
 	assert.Nil(t, err)
 
 	invitedUsers := []*models.User{user}
 	_, err = rocket.InviteChannel(general, invitedUsers)
+	assert.Nil(t, err)
+}
+
+func TestRocket_JoinChannel(t *testing.T) {
+	rocket := getDefaultClient(t)
+
+	general := &models.Channel{ID: "GENERAL"}
+	_, err := rocket.JoinChannel(general, "")
 	assert.Nil(t, err)
 }

--- a/rest/channels_test.go
+++ b/rest/channels_test.go
@@ -49,7 +49,25 @@ func TestRocket_GetChannelInfo(t *testing.T) {
 func TestRocket_CreateChannel(t *testing.T) {
 	rocket := getDefaultClient(t)
 
-	channel := &CreateChannel{ChannelName: "TestRocket_CreateChannel"}
+	// create channel with same name as testUserName so that channels aren't duplicated
+	channel := &CreateChannel{ChannelName: testUserName}
 	_, err := rocket.CreateChannel(channel)
+	assert.Nil(t, err)
+}
+
+func TestRocket_InviteChannel(t *testing.T) {
+	rocket := getDefaultClient(t)
+
+	// channel := &CreateChannel{ChannelName: "GENERAL"}
+	// resp, err := rocket.CreateChannel(channel)
+	// assert.Nil(t, err)
+
+	general := &models.Channel{ID: "GENERAL"}
+	// needs users.info to get userID
+	user, err := rocket.UserInfo(testUserName)
+	assert.Nil(t, err)
+
+	invitedUsers := []*models.User{user}
+	_, err = rocket.InviteChannel(general, invitedUsers)
 	assert.Nil(t, err)
 }

--- a/rest/channels_test.go
+++ b/rest/channels_test.go
@@ -45,3 +45,11 @@ func TestRocket_GetChannelInfo(t *testing.T) {
 	assert.NotEmpty(t, updatedChannelInfo.UpdatedAt)
 	assert.NotEmpty(t, updatedChannelInfo.Timestamp)
 }
+
+func TestRocket_CreateChannel(t *testing.T) {
+	rocket := getDefaultClient(t)
+
+	channel := &CreateChannel{ChannelName: "TestRocket_CreateChannel"}
+	_, err := rocket.CreateChannel(channel)
+	assert.Nil(t, err)
+}

--- a/rest/channels_test.go
+++ b/rest/channels_test.go
@@ -50,8 +50,7 @@ func TestRocket_CreateChannel(t *testing.T) {
 	rocket := getDefaultClient(t)
 
 	// create channel with same name as testUserName so that channels aren't duplicated
-	channel := &CreateChannel{ChannelName: testUserName}
-	_, err := rocket.CreateChannel(channel)
+	_, err := rocket.CreateChannel(testUserName, nil, false)
 	assert.Nil(t, err)
 }
 

--- a/rest/channels_test.go
+++ b/rest/channels_test.go
@@ -79,7 +79,6 @@ func TestRocket_GetChannelMembers(t *testing.T) {
 		general := &models.Channel{Name: "general"}
 		members, err := rocket.GetChannelMembers(general)
 		assert.Nil(t, err)
-		// are new users added to general by default?
 		assert.GreaterOrEqual(t, len(members), 1)
 
 	})

--- a/rest/groups.go
+++ b/rest/groups.go
@@ -1,0 +1,49 @@
+package rest
+
+import (
+	"net/url"
+
+	"github.com/RocketChat/Rocket.Chat.Go.SDK/models"
+)
+
+type GroupsResponse struct {
+	Status
+	models.Pagination
+	Groups []models.Channel `json:"groups"`
+}
+
+type GroupResponse struct {
+	Status
+	Group models.Channel `json:"group"`
+}
+
+// GetPrivateGroups returns all channels that can be seen by the logged in user.
+//
+// https://rocket.chat/docs/developer-guides/rest-api/groups/list
+func (c *Client) GetPrivateGroups() (*GroupsResponse, error) {
+	response := new(GroupsResponse)
+	if err := c.Get("groups.list", nil, response); err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+// GetGroupInfo get information about a group. That might be useful to update the usernames.
+//
+// https://rocket.chat/docs/developer-guides/rest-api/groups/info
+func (c *Client) GetGroupInfo(channel *models.Channel) (*models.Channel, error) {
+	response := new(GroupResponse)
+	switch {
+	case channel.Name != "" && channel.ID == "":
+		if err := c.Get("groups.info", url.Values{"roomName": []string{channel.Name}}, response); err != nil {
+			return nil, err
+		}
+	default:
+		if err := c.Get("groups.info", url.Values{"roomId": []string{channel.ID}}, response); err != nil {
+			return nil, err
+		}
+	}
+
+	return &response.Group, nil
+}

--- a/rest/users.go
+++ b/rest/users.go
@@ -75,7 +75,7 @@ func (s UserStatusResponse) OK() error {
 	return ResponseErr
 }
 
-type UserInfoResponse struct {
+type userInfoResponse struct {
 	User *models.User `json:"user"`
 	Status
 }
@@ -192,7 +192,7 @@ func (c *Client) UserInfo(username string) (*models.User, error) {
 	params := url.Values{
 		"username": []string{username},
 	}
-	response := new(UserInfoResponse)
+	response := new(userInfoResponse)
 	err := c.Get("users.info", params, response)
 	return response.User, err
 

--- a/rest/users.go
+++ b/rest/users.go
@@ -75,6 +75,11 @@ func (s UserStatusResponse) OK() error {
 	return ResponseErr
 }
 
+type UserInfoResponse struct {
+	User *models.User `json:"user"`
+	Status
+}
+
 // Login a user. The Email and the Password are mandatory. The auth token of the user is stored in the Client instance.
 //
 // https://rocket.chat/docs/developer-guides/rest-api/authentication/login
@@ -177,4 +182,18 @@ func (c *Client) GetUserStatus(username string) (*UserStatusResponse, error) {
 	response := new(UserStatusResponse)
 	err := c.Get("users.getStatus", params, response)
 	return response, err
+}
+
+// UserInfo retrieves information about a user.
+// The result is only limited to what the callee has access to view.
+//
+// https://developer.rocket.chat/reference/api/rest-api/endpoints/core-endpoints/users-endpoints/get-users-info
+func (c *Client) UserInfo(username string) (*models.User, error) {
+	params := url.Values{
+		"username": []string{username},
+	}
+	response := new(UserInfoResponse)
+	err := c.Get("users.info", params, response)
+	return response.User, err
+
 }

--- a/rest/users_test.go
+++ b/rest/users_test.go
@@ -16,3 +16,10 @@ func TestRocket_LoginLogout(t *testing.T) {
 	// assert.Nil(t, channels)
 	// assert.NotNil(t, err)
 }
+
+func TestRocket_UserInfo(t *testing.T) {
+	rocket := getDefaultClient(t)
+	user, err := rocket.UserInfo(testUserName)
+	assert.Nil(t, err)
+	assert.NotNil(t, user)
+}


### PR DESCRIPTION
This PR adds methods and tests to cover the following endpoints:

- [x] channels.create
- [x] channels.invite
- [x] channels.join
- [x] channels.members
- [x] users.info 

The method for `users.info` was required to retrieve user IDs for testing of `channels.invite`. 

Additionally, this PR moves `groups` methods out of the channels file and into a new file. 

