### PR TITLE
Add methods to expand coverage of `users` endpoints

### DIFF
--- a/models/team.go
+++ b/models/team.go
@@ -1,0 +1,17 @@
+package models
+
+import "time"
+
+type Team struct {
+	ID        string    `json:"_id"`
+	Name      string    `json:"name"`
+	Type      int       `json:"type"`
+	CreatedAt time.Time `json:"createdAt"`
+	CreatedBy struct {
+		ID       string `json:"_id"`
+		Username string `json:"username"`
+	} `json:"createdBy"`
+	UpdatedAt time.Time `json:"_updatedAt"`
+	RoomID    string    `json:"roomId"`
+	IsOwner   bool      `json:"isOwner"`
+}

--- a/models/user.go
+++ b/models/user.go
@@ -30,6 +30,8 @@ type UpdateUserRequest struct {
 }
 
 type Preferences struct {
+	User                        string `json:"user,omitempty"`
+	Language                    string `json:"language,omitempty"`
 	EnableAutoAway              bool   `json:"enableAutoAway,omitempty"`
 	IdleTimeoutLimit            int    `json:"idleTimeoutLimit,omitempty"`
 	DesktopNotificationDuration int    `json:"desktopNotificationDuration,omitempty"`
@@ -61,6 +63,10 @@ type Preferences struct {
 	NotificationsSoundVolume    int    `json:"notificationsSoundVolume,omitempty"`
 }
 
+type Settings struct {
+	Preferences `json:"preferences"`
+}
+
 type Email struct {
 	Address  string `json:"address"`
 	Verified bool   `json:"verified"`
@@ -73,10 +79,8 @@ type Me struct {
 	UtcOffset        int      `json:"utcOffset"`
 	Active           bool     `json:"active"`
 	Roles            []string `json:"roles"`
-	Settings         struct {
-		Preferences `json:"preferences"`
-	} `json:"settings"`
-	CustomFields struct {
+	Settings         Settings `json:"settings"`
+	CustomFields     struct {
 		Twitter string `json:"twitter,omitempty"`
 	} `json:"customFields,omitempty"`
 	AvatarURL string `json:"avatarUrl"`

--- a/models/user.go
+++ b/models/user.go
@@ -28,3 +28,56 @@ type UpdateUserRequest struct {
 		CustomFields map[string]string `json:"customFields,omitempty"`
 	} `json:"data"`
 }
+
+type Preferences struct {
+	EnableAutoAway              bool   `json:"enableAutoAway,omitempty"`
+	IdleTimeoutLimit            int    `json:"idleTimeoutLimit,omitempty"`
+	DesktopNotificationDuration int    `json:"desktopNotificationDuration,omitempty"`
+	AudioNotifications          string `json:"audioNotifications,omitempty"`
+	DesktopNotifications        string `json:"desktopNotifications,omitempty"`
+	MobileNotifications         string `json:"mobileNotifications,omitempty"`
+	UnreadAlert                 bool   `json:"unreadAlert,omitempty"`
+	UseEmojis                   bool   `json:"useEmojis,omitempty"`
+	ConvertASCIIEmoji           bool   `json:"convertAsciiEmoji,omitempty"`
+	AutoImageLoad               bool   `json:"autoImageLoad,omitempty"`
+	SaveMobileBandwidth         bool   `json:"saveMobileBandwidth,omitempty"`
+	CollapseMediaByDefault      bool   `json:"collapseMediaByDefault,omitempty"`
+	HideUsernames               bool   `json:"hideUsernames,omitempty"`
+	HideRoles                   bool   `json:"hideRoles,omitempty"`
+	HideFlexTab                 bool   `json:"hideFlexTab,omitempty"`
+	HideAvatars                 bool   `json:"hideAvatars,omitempty"`
+	RoomsListExhibitionMode     string `json:"roomsListExhibitionMode,omitempty"`
+	SidebarViewMode             string `json:"sidebarViewMode,omitempty"`
+	SidebarHideAvatar           bool   `json:"sidebarHideAvatar,omitempty"`
+	SidebarShowUnread           bool   `json:"sidebarShowUnread,omitempty"`
+	SidebarShowFavorites        bool   `json:"sidebarShowFavorites,omitempty"`
+	SendOnEnter                 string `json:"sendOnEnter,omitempty"`
+	MessageViewMode             int    `json:"messageViewMode,omitempty"`
+	EmailNotificationMode       string `json:"emailNotificationMode,omitempty"`
+	RoomCounterSidebar          bool   `json:"roomCounterSidebar,omitempty"`
+	NewRoomNotification         string `json:"newRoomNotification,omitempty"`
+	NewMessageNotification      string `json:"newMessageNotification,omitempty"`
+	MuteFocusedConversations    bool   `json:"muteFocusedConversations,omitempty"`
+	NotificationsSoundVolume    int    `json:"notificationsSoundVolume,omitempty"`
+}
+
+type Email struct {
+	Address  string `json:"address"`
+	Verified bool   `json:"verified"`
+}
+
+type Me struct {
+	User
+	Emails           []Email  `json:"emails"`
+	StatusConnection string   `json:"statusConnection"`
+	UtcOffset        int      `json:"utcOffset"`
+	Active           bool     `json:"active"`
+	Roles            []string `json:"roles"`
+	Settings         struct {
+		Preferences `json:"preferences"`
+	} `json:"settings"`
+	CustomFields struct {
+		Twitter string `json:"twitter,omitempty"`
+	} `json:"customFields,omitempty"`
+	AvatarURL string `json:"avatarUrl"`
+}

--- a/rest/users.go
+++ b/rest/users.go
@@ -75,6 +75,16 @@ type usersResponse struct {
 	Users []models.User `json:"users"`
 }
 
+type preferencesResponse struct {
+	Status
+	Preferenses models.Preferences `json:"preferences"`
+}
+
+type settingsResponse struct {
+	Status
+	Settings models.Settings `json:"settings"`
+}
+
 func (s UserStatusResponse) OK() error {
 	if s.Success {
 		return nil
@@ -207,14 +217,14 @@ func (c *Client) Me() (*models.Me, error) {
 // GetAvatar gets the URL for a user’s avatar.
 //
 // https://developer.rocket.chat/reference/api/rest-api/endpoints/core-endpoints/users-endpoints/get-avatar
-func (c *Client) GetAvatar(username string) (*avatarResponse, error) {
+func (c *Client) GetAvatar(username string) (string, error) {
 	params := url.Values{
 		"username": []string{username},
 	}
 	response := new(avatarResponse)
 	err := c.Get("users.getAvatar", params, response)
 	fmt.Println(response)
-	return response, err
+	return response.Url, err
 }
 
 // GetUsers gets all of the users in the system and their information.
@@ -234,4 +244,29 @@ func (c *Client) GetUsers(page *models.Pagination) ([]models.User, error) {
 		return nil, err
 	}
 	return response.Users, nil
+}
+
+// GetPreferences gets all preferences of the user.
+//
+// https://developer.rocket.chat/reference/api/rest-api/endpoints/core-endpoints/users-endpoints/get-user-preferences
+func (c *Client) GetPreferences() (*models.Preferences, error) {
+	response := new(preferencesResponse)
+	err := c.Get("users.getPreferences", nil, response)
+	return &response.Preferenses, err
+}
+
+// SetPreferences sets preferences of the user.
+//
+// https://developer.rocket.chat/reference/api/rest-api/endpoints/core-endpoints/users-endpoints/set-preferences
+func (c *Client) SetPreferences(preferences *models.Preferences) (*models.Preferences, error) {
+
+	body, err := json.Marshal(preferences)
+	if err != nil {
+		return nil, err
+	}
+
+	response := new(settingsResponse)
+	err = c.Post("users.saveUserPreferences", bytes.NewBuffer(body), response)
+	return &response.Settings.Preferences, err
+
 }

--- a/rest/users.go
+++ b/rest/users.go
@@ -59,6 +59,11 @@ type UserStatusResponse struct {
 	Success          bool   `json:"success"`
 }
 
+type meResponse struct {
+	models.Me
+	Status
+}
+
 func (s UserStatusResponse) OK() error {
 	if s.Success {
 		return nil
@@ -177,4 +182,13 @@ func (c *Client) GetUserStatus(username string) (*UserStatusResponse, error) {
 	response := new(UserStatusResponse)
 	err := c.Get("users.getStatus", params, response)
 	return response, err
+}
+
+// Me returns quick information about the authenticated user.
+//
+// https://developer.rocket.chat/reference/api/rest-api/endpoints/other-important-endpoints/authentication-endpoints/me
+func (c *Client) Me() (*models.Me, error) {
+	response := new(meResponse)
+	err := c.Get("me", nil, response)
+	return &response.Me, err
 }

--- a/rest/users_test.go
+++ b/rest/users_test.go
@@ -18,6 +18,13 @@ func TestRocket_LoginLogout(t *testing.T) {
 	// assert.NotNil(t, err)
 }
 
+func TestRocket_UserInfo(t *testing.T) {
+	rocket := getDefaultClient(t)
+	user, err := rocket.UserInfo(testUserName)
+	assert.Nil(t, err)
+	assert.NotNil(t, user)
+}
+
 func TestRocket_Me(t *testing.T) {
 	rocket := getDefaultClient(t)
 	me, err := rocket.Me()
@@ -55,4 +62,13 @@ func TestRocket_SetPreferences(t *testing.T) {
 	updatedPreferences, err := rocket.SetPreferences(preferences)
 	assert.Nil(t, err)
 	assert.NotNil(t, updatedPreferences)
+}
+
+func TestRocket_ListTeams(t *testing.T) {
+	rocket := getDefaultClient(t)
+	user, err := rocket.UserInfo(testUserName)
+	assert.Nil(t, err)
+	teams, err := rocket.ListTeams(user)
+	assert.Nil(t, err)
+	assert.NotNil(t, teams)
 }

--- a/rest/users_test.go
+++ b/rest/users_test.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/RocketChat/Rocket.Chat.Go.SDK/common_testing"
@@ -15,4 +16,14 @@ func TestRocket_LoginLogout(t *testing.T) {
 	// channels, err := client.GetJoinedChannels()
 	// assert.Nil(t, channels)
 	// assert.NotNil(t, err)
+}
+
+func TestRocket_Me(t *testing.T) {
+	rocket := getDefaultClient(t)
+	me, err := rocket.Me()
+	fmt.Println(me)
+	assert.Nil(t, err)
+	assert.NotNil(t, me)
+	assert.Equal(t, testUserEmail, me.Emails[0].Address)
+	assert.Equal(t, testUserName, me.UserName)
 }

--- a/rest/users_test.go
+++ b/rest/users_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/RocketChat/Rocket.Chat.Go.SDK/common_testing"
+	"github.com/RocketChat/Rocket.Chat.Go.SDK/models"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -39,4 +40,19 @@ func TestRocket_GetUsers(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, users)
 	assert.GreaterOrEqual(t, len(users), 1)
+}
+
+func TestRocket_GetPreferences(t *testing.T) {
+	rocket := getDefaultClient(t)
+	pref, err := rocket.GetPreferences()
+	assert.Nil(t, err)
+	assert.NotNil(t, pref)
+}
+
+func TestRocket_SetPreferences(t *testing.T) {
+	rocket := getDefaultClient(t)
+	preferences := &models.Preferences{User: testUserName}
+	updatedPreferences, err := rocket.SetPreferences(preferences)
+	assert.Nil(t, err)
+	assert.NotNil(t, updatedPreferences)
 }

--- a/rest/users_test.go
+++ b/rest/users_test.go
@@ -1,7 +1,6 @@
 package rest
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/RocketChat/Rocket.Chat.Go.SDK/common_testing"
@@ -21,9 +20,23 @@ func TestRocket_LoginLogout(t *testing.T) {
 func TestRocket_Me(t *testing.T) {
 	rocket := getDefaultClient(t)
 	me, err := rocket.Me()
-	fmt.Println(me)
 	assert.Nil(t, err)
 	assert.NotNil(t, me)
 	assert.Equal(t, testUserEmail, me.Emails[0].Address)
 	assert.Equal(t, testUserName, me.UserName)
+}
+
+func TestRocket_GetAvatar(t *testing.T) {
+	rocket := getDefaultClient(t)
+	url, err := rocket.GetAvatar(testUserName)
+	assert.Nil(t, err)
+	assert.NotNil(t, url)
+}
+
+func TestRocket_GetUsers(t *testing.T) {
+	rocket := getDefaultClient(t)
+	users, err := rocket.GetUsers(nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, users)
+	assert.GreaterOrEqual(t, len(users), 1)
 }


### PR DESCRIPTION
This PR adds types, methods and tests to cover the following endpoints:

- [x] me
- [ ] users.getAvatar
- [x] users.info
- [x] users.list
- [ ] users.getPreferences 
- [ ] users.setPreferences 
- [ ] users.listTeams 

