### PR TITLE
Improve method return values and scope limiting 

### DIFF
--- a/models/channel.go
+++ b/models/channel.go
@@ -37,3 +37,10 @@ type ChannelSubscription struct {
 	Roles       []string `json:"roles"`
 	Unread      float64  `json:"unread"`
 }
+
+type Room struct {
+	ID        string   `json:"_id"`
+	Rid       string   `json:"rid"`
+	Type      string   `json:"t"`
+	Usernames []string `json:"usernames"`
+}

--- a/models/user.go
+++ b/models/user.go
@@ -28,3 +28,9 @@ type UpdateUserRequest struct {
 		CustomFields map[string]string `json:"customFields,omitempty"`
 	} `json:"data"`
 }
+
+type UserStatus struct {
+	Message          string `json:"message"`
+	Status           string `json:"status"`
+	ConnectionStatus string `json:"connectionStatus"`
+}

--- a/models/user.go
+++ b/models/user.go
@@ -9,26 +9,6 @@ type User struct {
 	TokenExpires int64  `json:"tokenExpires"`
 }
 
-type CreateUserRequest struct {
-	Name         string            `json:"name"`
-	Email        string            `json:"email"`
-	Password     string            `json:"password"`
-	Username     string            `json:"username"`
-	Roles        []string          `json:"roles,omitempty"`
-	CustomFields map[string]string `json:"customFields,omitempty"`
-}
-
-type UpdateUserRequest struct {
-	UserID string `json:"userId"`
-	Data   struct {
-		Name         string            `json:"name"`
-		Email        string            `json:"email"`
-		Password     string            `json:"password"`
-		Username     string            `json:"username"`
-		CustomFields map[string]string `json:"customFields,omitempty"`
-	} `json:"data"`
-}
-
 type UserStatus struct {
 	Message          string `json:"message"`
 	Status           string `json:"status"`

--- a/rest/channels.go
+++ b/rest/channels.go
@@ -8,24 +8,24 @@ import (
 	"github.com/RocketChat/Rocket.Chat.Go.SDK/models"
 )
 
-type ChannelsResponse struct {
+type channelsResponse struct {
 	Status
 	models.Pagination
 	Channels []models.Channel `json:"channels"`
 }
 
-type ChannelResponse struct {
+type channelResponse struct {
 	Status
 	Channel models.Channel `json:"channel"`
 }
 
-type GroupsResponse struct {
+type groupsResponse struct {
 	Status
 	models.Pagination
 	Groups []models.Channel `json:"groups"`
 }
 
-type GroupResponse struct {
+type groupResponse struct {
 	Status
 	Group models.Channel `json:"group"`
 }
@@ -34,7 +34,7 @@ type GroupResponse struct {
 //
 // https://rocket.chat/docs/developer-guides/rest-api/channels/list
 func (c *Client) GetPublicChannels() ([]models.Channel, error) {
-	response := new(ChannelsResponse)
+	response := new(channelsResponse)
 	if err := c.Get("channels.list", nil, response); err != nil {
 		return nil, err
 	}
@@ -46,7 +46,7 @@ func (c *Client) GetPublicChannels() ([]models.Channel, error) {
 //
 // https://rocket.chat/docs/developer-guides/rest-api/groups/list
 func (c *Client) GetPrivateGroups() ([]models.Channel, error) {
-	response := new(GroupsResponse)
+	response := new(groupsResponse)
 	if err := c.Get("groups.list", nil, response); err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func (c *Client) GetPrivateGroups() ([]models.Channel, error) {
 //
 // https://rocket.chat/docs/developer-guides/rest-api/channels/list-joined
 func (c *Client) GetJoinedChannels(params url.Values) ([]models.Channel, error) {
-	response := new(ChannelsResponse)
+	response := new(channelsResponse)
 	if err := c.Get("channels.list.joined", params, response); err != nil {
 		return nil, err
 	}
@@ -71,14 +71,14 @@ func (c *Client) GetJoinedChannels(params url.Values) ([]models.Channel, error) 
 // https://rocket.chat/docs/developer-guides/rest-api/channels/leave
 func (c *Client) LeaveChannel(channel *models.Channel) error {
 	var body = fmt.Sprintf(`{ "roomId": "%s"}`, channel.ID)
-	return c.Post("channels.leave", bytes.NewBufferString(body), new(ChannelResponse))
+	return c.Post("channels.leave", bytes.NewBufferString(body), new(channelResponse))
 }
 
 // GetChannelInfo get information about a channel. That might be useful to update the usernames.
 //
 // https://rocket.chat/docs/developer-guides/rest-api/channels/info
 func (c *Client) GetChannelInfo(channel *models.Channel) (*models.Channel, error) {
-	response := new(ChannelResponse)
+	response := new(channelResponse)
 	switch {
 	case channel.Name != "" && channel.ID == "":
 		if err := c.Get("channels.info", url.Values{"roomName": []string{channel.Name}}, response); err != nil {
@@ -97,7 +97,7 @@ func (c *Client) GetChannelInfo(channel *models.Channel) (*models.Channel, error
 //
 // https://rocket.chat/docs/developer-guides/rest-api/groups/info
 func (c *Client) GetGroupInfo(channel *models.Channel) (*models.Channel, error) {
-	response := new(GroupResponse)
+	response := new(groupResponse)
 	switch {
 	case channel.Name != "" && channel.ID == "":
 		if err := c.Get("groups.info", url.Values{"roomName": []string{channel.Name}}, response); err != nil {

--- a/rest/channels.go
+++ b/rest/channels.go
@@ -33,37 +33,37 @@ type GroupResponse struct {
 // GetPublicChannels returns all channels that can be seen by the logged in user.
 //
 // https://rocket.chat/docs/developer-guides/rest-api/channels/list
-func (c *Client) GetPublicChannels() (*ChannelsResponse, error) {
+func (c *Client) GetPublicChannels() ([]models.Channel, error) {
 	response := new(ChannelsResponse)
 	if err := c.Get("channels.list", nil, response); err != nil {
 		return nil, err
 	}
 
-	return response, nil
+	return response.Channels, nil
 }
 
 // GetPrivateGroups returns all channels that can be seen by the logged in user.
 //
 // https://rocket.chat/docs/developer-guides/rest-api/groups/list
-func (c *Client) GetPrivateGroups() (*GroupsResponse, error) {
+func (c *Client) GetPrivateGroups() ([]models.Channel, error) {
 	response := new(GroupsResponse)
 	if err := c.Get("groups.list", nil, response); err != nil {
 		return nil, err
 	}
 
-	return response, nil
+	return response.Groups, nil
 }
 
 // GetJoinedChannels returns all channels that the user has joined.
 //
 // https://rocket.chat/docs/developer-guides/rest-api/channels/list-joined
-func (c *Client) GetJoinedChannels(params url.Values) (*ChannelsResponse, error) {
+func (c *Client) GetJoinedChannels(params url.Values) ([]models.Channel, error) {
 	response := new(ChannelsResponse)
 	if err := c.Get("channels.list.joined", params, response); err != nil {
 		return nil, err
 	}
 
-	return response, nil
+	return response.Channels, nil
 }
 
 // LeaveChannel leaves a channel. The id of the channel has to be not nil.

--- a/rest/channels_test.go
+++ b/rest/channels_test.go
@@ -10,17 +10,17 @@ import (
 func TestRocket_GetPublicChannels(t *testing.T) {
 	rocket := getDefaultClient(t)
 
-	resp, err := rocket.GetPublicChannels()
+	channels, err := rocket.GetPublicChannels()
 	assert.Nil(t, err)
-	assert.NotZero(t, len(resp.Channels))
+	assert.NotZero(t, len(channels))
 }
 
 func TestRocket_GetJoinedChannels(t *testing.T) {
 	rocket := getDefaultClient(t)
 
-	resp, err := rocket.GetJoinedChannels(nil)
+	channels, err := rocket.GetJoinedChannels(nil)
 	assert.Nil(t, err)
-	assert.NotZero(t, len(resp.Channels))
+	assert.NotZero(t, len(channels))
 }
 
 func TestRocket_LeaveChannel(t *testing.T) {

--- a/rest/im.go
+++ b/rest/im.go
@@ -3,33 +3,25 @@ package rest
 import (
 	"bytes"
 	"fmt"
-	"log"
+
+	"github.com/RocketChat/Rocket.Chat.Go.SDK/models"
 )
 
 type directMessageResponse struct {
 	Status
-	Room Room `json:"room"`
-}
-
-type Room struct {
-	ID        string   `json:"_id"`
-	Rid       string   `json:"rid"`
-	Type      string   `json:"t"`
-	Usernames []string `json:"usernames"`
+	Room models.Room `json:"room"`
 }
 
 // Creates a DirectMessage
 //
 // https://developer.rocket.chat/api/rest-api/methods/im/create
-func (c *Client) CreateDirectMessage(username string) (*Room, error) {
+func (c *Client) CreateDirectMessage(username string) (*models.Room, error) {
 	body := fmt.Sprintf(`{ "username": "%s" }`, username)
 	resp := new(directMessageResponse)
 
 	if err := c.Post("im.create", bytes.NewBufferString(body), resp); err != nil {
 		return nil, err
 	}
-
-	log.Println(resp)
 
 	return &resp.Room, nil
 }

--- a/rest/im.go
+++ b/rest/im.go
@@ -6,7 +6,7 @@ import (
 	"log"
 )
 
-type DirectMessageResponse struct {
+type directMessageResponse struct {
 	Status
 	Room Room `json:"room"`
 }
@@ -14,7 +14,7 @@ type DirectMessageResponse struct {
 type Room struct {
 	ID        string   `json:"_id"`
 	Rid       string   `json:"rid"`
-	Type         string   `json:"t"`
+	Type      string   `json:"t"`
 	Usernames []string `json:"usernames"`
 }
 
@@ -23,7 +23,7 @@ type Room struct {
 // https://developer.rocket.chat/api/rest-api/methods/im/create
 func (c *Client) CreateDirectMessage(username string) (*Room, error) {
 	body := fmt.Sprintf(`{ "username": "%s" }`, username)
-	resp := new(DirectMessageResponse)
+	resp := new(directMessageResponse)
 
 	if err := c.Post("im.create", bytes.NewBufferString(body), resp); err != nil {
 		return nil, err

--- a/rest/im_test.go
+++ b/rest/im_test.go
@@ -1,0 +1,15 @@
+package rest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRocket_CreateDirectMessage(t *testing.T) {
+	rocket := getDefaultClient(t)
+
+	room, err := rocket.CreateDirectMessage(testUserName)
+	assert.Nil(t, err)
+	assert.NotNil(t, room)
+}

--- a/rest/information.go
+++ b/rest/information.go
@@ -6,7 +6,7 @@ import (
 	"github.com/RocketChat/Rocket.Chat.Go.SDK/models"
 )
 
-type InfoResponse struct {
+type infoResponse struct {
 	Status
 	Info models.Info `json:"info"`
 }
@@ -16,7 +16,7 @@ type InfoResponse struct {
 //
 // https://rocket.chat/docs/developer-guides/rest-api/miscellaneous/info
 func (c *Client) GetServerInfo() (*models.Info, error) {
-	response := new(InfoResponse)
+	response := new(infoResponse)
 	if err := c.Get("info", nil, response); err != nil {
 		return nil, err
 	}
@@ -24,7 +24,7 @@ func (c *Client) GetServerInfo() (*models.Info, error) {
 	return &response.Info, nil
 }
 
-type DirectoryResponse struct {
+type directoryResponse struct {
 	Status
 	models.Directory
 }
@@ -34,7 +34,7 @@ type DirectoryResponse struct {
 //
 // https://rocket.chat/docs/developer-guides/rest-api/miscellaneous/directory
 func (c *Client) GetDirectory(params url.Values) (*models.Directory, error) {
-	response := new(DirectoryResponse)
+	response := new(directoryResponse)
 	if err := c.Get("directory", params, response); err != nil {
 		return nil, err
 	}
@@ -42,7 +42,7 @@ func (c *Client) GetDirectory(params url.Values) (*models.Directory, error) {
 	return &response.Directory, nil
 }
 
-type SpotlightResponse struct {
+type spotlightResponse struct {
 	Status
 	models.Spotlight
 }
@@ -52,7 +52,7 @@ type SpotlightResponse struct {
 //
 // https://rocket.chat/docs/developer-guides/rest-api/miscellaneous/spotlight
 func (c *Client) GetSpotlight(params url.Values) (*models.Spotlight, error) {
-	response := new(SpotlightResponse)
+	response := new(spotlightResponse)
 	if err := c.Get("spotlight", params, response); err != nil {
 		return nil, err
 	}
@@ -60,7 +60,7 @@ func (c *Client) GetSpotlight(params url.Values) (*models.Spotlight, error) {
 	return &response.Spotlight, nil
 }
 
-type StatisticsResponse struct {
+type statisticsResponse struct {
 	Status
 	models.StatisticsInfo
 }
@@ -70,7 +70,7 @@ type StatisticsResponse struct {
 //
 // https://rocket.chat/docs/developer-guides/rest-api/miscellaneous/statistics
 func (c *Client) GetStatistics() (*models.StatisticsInfo, error) {
-	response := new(StatisticsResponse)
+	response := new(statisticsResponse)
 	if err := c.Get("statistics", nil, response); err != nil {
 		return nil, err
 	}
@@ -78,7 +78,7 @@ func (c *Client) GetStatistics() (*models.StatisticsInfo, error) {
 	return &response.StatisticsInfo, nil
 }
 
-type StatisticsListResponse struct {
+type statisticsListResponse struct {
 	Status
 	models.StatisticsList
 }
@@ -89,7 +89,7 @@ type StatisticsListResponse struct {
 //
 // https://rocket.chat/docs/developer-guides/rest-api/miscellaneous/statistics.list
 func (c *Client) GetStatisticsList(params url.Values) (*models.StatisticsList, error) {
-	response := new(StatisticsListResponse)
+	response := new(statisticsListResponse)
 	if err := c.Get("statistics.list", params, response); err != nil {
 		return nil, err
 	}

--- a/rest/messages.go
+++ b/rest/messages.go
@@ -39,7 +39,7 @@ func (c *Client) Send(channel *models.Channel, msg string) error {
 // The message will be json encode.
 //
 // https://rocket.chat/docs/developer-guides/rest-api/chat/postmessage
-func (c *Client) PostMessage(msg *models.PostMessage) (*MessageResponse, error) {
+func (c *Client) PostMessage(msg *models.PostMessage) (*models.Message, error) {
 	body, err := json.Marshal(msg)
 	if err != nil {
 		return nil, err
@@ -47,7 +47,7 @@ func (c *Client) PostMessage(msg *models.PostMessage) (*MessageResponse, error) 
 
 	response := new(MessageResponse)
 	err = c.Post("chat.postMessage", bytes.NewBuffer(body), response)
-	return response, err
+	return &response.Message, err
 }
 
 // GetMessage retrieves a single chat message by the provided id.
@@ -113,7 +113,7 @@ func (c *Client) GetMentionedMessages(channel *models.Channel, page *models.Pagi
 // UpdateMessage updates a specific message.
 //
 // https://developer.rocket.chat/reference/api/rest-api/endpoints/core-endpoints/chat-endpoints/message-update
-func (c *Client) UpdateMessage(msg *models.UpdateMessage) (*MessageResponse, error) {
+func (c *Client) UpdateMessage(msg *models.UpdateMessage) (*models.Message, error) {
 	body, err := json.Marshal(msg)
 	if err != nil {
 		return nil, err
@@ -121,14 +121,14 @@ func (c *Client) UpdateMessage(msg *models.UpdateMessage) (*MessageResponse, err
 
 	response := new(MessageResponse)
 	err = c.Post("chat.update", bytes.NewBuffer(body), response)
-	return response, err
+	return &response.Message, err
 
 }
 
 // DeleteMessage deletes a specific message.
 //
 // https://developer.rocket.chat/reference/api/rest-api/endpoints/core-endpoints/chat-endpoints/delete
-func (c *Client) DeleteMessage(msg *models.DeleteMessage) (*DeleteMessageResponse, error) {
+func (c *Client) DeleteMessage(msg *models.DeleteMessage) (*models.Message, error) {
 	body, err := json.Marshal(msg)
 	if err != nil {
 		return nil, err
@@ -136,7 +136,7 @@ func (c *Client) DeleteMessage(msg *models.DeleteMessage) (*DeleteMessageRespons
 
 	response := new(DeleteMessageResponse)
 	err = c.Post("chat.delete", bytes.NewBuffer(body), response)
-	return response, err
+	return &response.Message, err
 }
 
 // SearchMessages searches for messages in a channel by id and text message

--- a/rest/messages.go
+++ b/rest/messages.go
@@ -11,17 +11,17 @@ import (
 	"github.com/RocketChat/Rocket.Chat.Go.SDK/models"
 )
 
-type MessagesResponse struct {
+type messagesResponse struct {
 	Status
 	Messages []models.Message `json:"messages"`
 }
 
-type MessageResponse struct {
+type messageResponse struct {
 	Status
 	Message models.Message `json:"message"`
 }
 
-type DeleteMessageResponse struct {
+type deleteMessageResponse struct {
 	Status
 	Message models.Message
 }
@@ -32,7 +32,7 @@ type DeleteMessageResponse struct {
 // https://rocket.chat/docs/developer-guides/rest-api/chat/postmessage
 func (c *Client) Send(channel *models.Channel, msg string) error {
 	body := fmt.Sprintf(`{ "channel": "%s", "text": "%s"}`, channel.Name, html.EscapeString(msg))
-	return c.Post("chat.postMessage", bytes.NewBufferString(body), new(MessageResponse))
+	return c.Post("chat.postMessage", bytes.NewBufferString(body), new(messageResponse))
 }
 
 // PostMessage send a message to a channel. The channel or roomId has to be not nil.
@@ -45,7 +45,7 @@ func (c *Client) PostMessage(msg *models.PostMessage) (*models.Message, error) {
 		return nil, err
 	}
 
-	response := new(MessageResponse)
+	response := new(messageResponse)
 	err = c.Post("chat.postMessage", bytes.NewBuffer(body), response)
 	return &response.Message, err
 }
@@ -59,7 +59,7 @@ func (c *Client) GetMessage(msgId string) (models.Message, error) {
 	params := url.Values{
 		"msgId": []string{msgId},
 	}
-	response := new(MessageResponse)
+	response := new(messageResponse)
 	if err := c.Get("chat.getMessage", params, response); err != nil {
 		return models.Message{}, err
 	}
@@ -80,7 +80,7 @@ func (c *Client) GetMessages(channel *models.Channel, page *models.Pagination) (
 		params.Add("offset", strconv.Itoa(page.Offset))
 	}
 
-	response := new(MessagesResponse)
+	response := new(messagesResponse)
 	if err := c.Get("channels.history", params, response); err != nil {
 		return nil, err
 	}
@@ -102,7 +102,7 @@ func (c *Client) GetMentionedMessages(channel *models.Channel, page *models.Pagi
 		params.Add("offset", strconv.Itoa(page.Offset))
 	}
 
-	response := new(MessagesResponse)
+	response := new(messagesResponse)
 	if err := c.Get("chat.getMentionedMessages", params, response); err != nil {
 		return nil, err
 	}
@@ -119,7 +119,7 @@ func (c *Client) UpdateMessage(msg *models.UpdateMessage) (*models.Message, erro
 		return nil, err
 	}
 
-	response := new(MessageResponse)
+	response := new(messageResponse)
 	err = c.Post("chat.update", bytes.NewBuffer(body), response)
 	return &response.Message, err
 
@@ -134,7 +134,7 @@ func (c *Client) DeleteMessage(msg *models.DeleteMessage) (*models.Message, erro
 		return nil, err
 	}
 
-	response := new(DeleteMessageResponse)
+	response := new(deleteMessageResponse)
 	err = c.Post("chat.delete", bytes.NewBuffer(body), response)
 	return &response.Message, err
 }
@@ -148,7 +148,7 @@ func (c *Client) SearchMessages(channel *models.Channel, searchText string) ([]m
 		"roomId":     []string{channel.ID},
 		"searchText": []string{searchText},
 	}
-	response := new(MessagesResponse)
+	response := new(messagesResponse)
 	if err := c.Get("chat.search", params, response); err != nil {
 		return nil, err
 	}

--- a/rest/messages_test.go
+++ b/rest/messages_test.go
@@ -26,11 +26,11 @@ func TestRocket_GetMessage(t *testing.T) {
 		Channel: "general",
 		Text:    text,
 	}
-	postResp, err := rocket.PostMessage(postMessage)
+	message, err := rocket.PostMessage(postMessage)
 	assert.Nil(t, err)
-	assert.NotNil(t, postResp)
+	assert.NotNil(t, message)
 
-	msgId := postResp.Message.ID
+	msgId := message.ID
 	msg, err := rocket.GetMessage(msgId)
 	assert.Nil(t, err)
 	assert.Equal(t, text, msg.Msg)
@@ -85,20 +85,20 @@ func TestRocket_UpdateMessage(t *testing.T) {
 		Channel: "general",
 		Text:    textOriginal,
 	}
-	postResp, err := rocket.PostMessage(postMessage)
+	message, err := rocket.PostMessage(postMessage)
 	assert.Nil(t, err)
-	assert.NotNil(t, postResp)
+	assert.NotNil(t, message)
 
-	roomId := postResp.Message.RoomID
-	msgId := postResp.Message.ID
+	roomId := message.RoomID
+	msgId := message.ID
 	updateMessage := &models.UpdateMessage{
 		RoomID: roomId,
 		MsgID:  msgId,
 		Text:   textUpdated,
 	}
-	resp, err := rocket.UpdateMessage(updateMessage)
+	returnMessage, err := rocket.UpdateMessage(updateMessage)
 	assert.Nil(t, err)
-	assert.Equal(t, textUpdated, resp.Message.Msg)
+	assert.Equal(t, textUpdated, returnMessage.Msg)
 }
 
 func TestRocket_DeleteMessage(t *testing.T) {
@@ -109,20 +109,20 @@ func TestRocket_DeleteMessage(t *testing.T) {
 			Channel: "general",
 			Text:    text,
 		}
-		postResp, err := rocket.PostMessage(postMessage)
+		message, err := rocket.PostMessage(postMessage)
 		assert.Nil(t, err)
-		assert.NotNil(t, postResp)
+		assert.NotNil(t, message)
 
-		roomId := postResp.Message.RoomID
-		msgId := postResp.Message.ID
+		roomId := message.RoomID
+		msgId := message.ID
 		deleteMessage := &models.DeleteMessage{
 			RoomID: roomId,
 			MsgID:  msgId,
 			AsUser: true,
 		}
-		resp, err := rocket.DeleteMessage(deleteMessage)
+		returnMessage, err := rocket.DeleteMessage(deleteMessage)
 		assert.Nil(t, err)
-		assert.NotNil(t, resp)
+		assert.NotNil(t, returnMessage)
 	})
 	t.Run("asUser = false", func(t *testing.T) {
 		text := "TestRocket_DeleteMessageNotAsUser"
@@ -130,20 +130,20 @@ func TestRocket_DeleteMessage(t *testing.T) {
 			Channel: "general",
 			Text:    text,
 		}
-		postResp, err := rocket.PostMessage(postMessage)
+		message, err := rocket.PostMessage(postMessage)
 		assert.Nil(t, err)
-		assert.NotNil(t, postResp)
+		assert.NotNil(t, message)
 
-		roomId := postResp.Message.RoomID
-		msgId := postResp.Message.ID
+		roomId := message.RoomID
+		msgId := message.ID
 		deleteMessage := &models.DeleteMessage{
 			RoomID: roomId,
 			MsgID:  msgId,
 			AsUser: false,
 		}
-		resp, err := rocket.DeleteMessage(deleteMessage)
+		returnMessage, err := rocket.DeleteMessage(deleteMessage)
 		assert.Nil(t, err)
-		assert.NotNil(t, resp)
+		assert.NotNil(t, returnMessage)
 	})
 }
 

--- a/rest/permissions.go
+++ b/rest/permissions.go
@@ -3,6 +3,7 @@ package rest
 import (
 	"bytes"
 	"encoding/json"
+
 	"github.com/RocketChat/Rocket.Chat.Go.SDK/models"
 )
 
@@ -18,7 +19,7 @@ type UpdatePermissionsResponse struct {
 // UpdatePermissions updates permissions
 //
 // https://rocket.chat/docs/developer-guides/rest-api/permissions/update/
-func (c *Client) UpdatePermissions(req *UpdatePermissionsRequest) (*UpdatePermissionsResponse, error) {
+func (c *Client) UpdatePermissions(req *UpdatePermissionsRequest) ([]models.Permission, error) {
 	body, err := json.Marshal(req)
 	if err != nil {
 		return nil, err
@@ -28,5 +29,5 @@ func (c *Client) UpdatePermissions(req *UpdatePermissionsRequest) (*UpdatePermis
 	if err := c.Post("permissions.update", bytes.NewBuffer(body), response); err != nil {
 		return nil, err
 	}
-	return response, nil
+	return response.Permissions, nil
 }

--- a/rest/permissions.go
+++ b/rest/permissions.go
@@ -7,11 +7,11 @@ import (
 	"github.com/RocketChat/Rocket.Chat.Go.SDK/models"
 )
 
-type UpdatePermissionsRequest struct {
+type updatePermissionsRequest struct {
 	Permissions []models.Permission `json:"permissions"`
 }
 
-type UpdatePermissionsResponse struct {
+type updatePermissionsResponse struct {
 	Status
 	Permissions []models.Permission `json:"permissions"`
 }
@@ -19,13 +19,14 @@ type UpdatePermissionsResponse struct {
 // UpdatePermissions updates permissions
 //
 // https://rocket.chat/docs/developer-guides/rest-api/permissions/update/
-func (c *Client) UpdatePermissions(req *UpdatePermissionsRequest) ([]models.Permission, error) {
+func (c *Client) UpdatePermissions(permissions []models.Permission) ([]models.Permission, error) {
+	req := updatePermissionsRequest{Permissions: permissions}
 	body, err := json.Marshal(req)
 	if err != nil {
 		return nil, err
 	}
 
-	response := new(UpdatePermissionsResponse)
+	response := new(updatePermissionsResponse)
 	if err := c.Post("permissions.update", bytes.NewBuffer(body), response); err != nil {
 		return nil, err
 	}

--- a/rest/permissions_test.go
+++ b/rest/permissions_test.go
@@ -11,12 +11,11 @@ import (
 func TestRocket_SetPermissions(t *testing.T) {
 	rocket := getDefaultClient(t)
 
-	request := UpdatePermissionsRequest{
-		Permissions: []models.Permission{{ID: "add-user-to-any-p-room", Roles: []string{"admin"}}},
-	}
-	permissions, err := rocket.UpdatePermissions(&request)
+	permissions := []models.Permission{{ID: "add-user-to-any-p-room", Roles: []string{"admin"}}}
+
+	returnPermissions, err := rocket.UpdatePermissions(permissions)
 
 	assert.Nil(t, err)
-	assert.NotNil(t, permissions)
-	assert.NotEmpty(t, permissions)
+	assert.NotNil(t, returnPermissions)
+	assert.NotEmpty(t, returnPermissions)
 }

--- a/rest/permissions_test.go
+++ b/rest/permissions_test.go
@@ -1,22 +1,22 @@
 package rest
 
 import (
-	"github.com/RocketChat/Rocket.Chat.Go.SDK/common_testing"
+	"testing"
+
 	"github.com/RocketChat/Rocket.Chat.Go.SDK/models"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 // you have to set access-permissions on role "user" to run this test successfully!
 func TestRocket_SetPermissions(t *testing.T) {
-	client := getAuthenticatedClient(t, common_testing.GetRandomString(), common_testing.GetRandomEmail(), common_testing.GetRandomString())
+	rocket := getDefaultClient(t)
 
 	request := UpdatePermissionsRequest{
 		Permissions: []models.Permission{{ID: "add-user-to-any-p-room", Roles: []string{"admin"}}},
 	}
-	response, err := client.UpdatePermissions(&request)
+	permissions, err := rocket.UpdatePermissions(&request)
 
 	assert.Nil(t, err)
-	assert.NotNil(t, response)
-	assert.NotEmpty(t, response.Permissions)
+	assert.NotNil(t, permissions)
+	assert.NotEmpty(t, permissions)
 }

--- a/rest/users.go
+++ b/rest/users.go
@@ -51,12 +51,10 @@ type CreateUserResponse struct {
 }
 
 type UserStatusResponse struct {
-	ID               string `json:"_id"`
-	ConnectionStatus string `json:"connectionStatus"`
-	Message          string `json:"message"`
-	Status           string `json:"status"`
-	Error            string `json:"error"`
-	Success          bool   `json:"success"`
+	models.UserStatus
+	ID      string `json:"_id"`
+	Error   string `json:"error"`
+	Success bool   `json:"success"`
 }
 
 func (s UserStatusResponse) OK() error {
@@ -133,48 +131,77 @@ func (c *Client) Logout() (string, error) {
 // CreateUser being logged in with a user that has permission to do so.
 //
 // https://rocket.chat/docs/developer-guides/rest-api/users/create
-func (c *Client) CreateUser(req *models.CreateUserRequest) (*CreateUserResponse, error) {
+func (c *Client) CreateUser(req *models.CreateUserRequest) (*models.User, error) {
 	body, err := json.Marshal(req)
 	if err != nil {
 		return nil, err
 	}
 
-	response := new(CreateUserResponse)
-	err = c.Post("users.create", bytes.NewBuffer(body), response)
-	return response, err
+	resp := new(CreateUserResponse)
+	if err := c.Post("users.create", bytes.NewBuffer(body), resp); err != nil {
+		return nil, err
+	}
+
+	createdUser := &models.User{
+		ID:       resp.User.ID,
+		Name:     resp.User.Name,
+		UserName: resp.User.Username,
+		Status:   resp.User.Status,
+	}
+
+	return createdUser, nil
 }
 
 // UpdateUser updates a user's data being logged in with a user that has permission to do so.
 //
 // https://rocket.chat/docs/developer-guides/rest-api/users/update/
-func (c *Client) UpdateUser(req *models.UpdateUserRequest) (*CreateUserResponse, error) {
+func (c *Client) UpdateUser(req *models.UpdateUserRequest) (*models.User, error) {
 	body, err := json.Marshal(req)
 	if err != nil {
 		return nil, err
 	}
 
-	response := new(CreateUserResponse)
-	err = c.Post("users.update", bytes.NewBuffer(body), response)
-	return response, err
+	resp := new(CreateUserResponse)
+	err = c.Post("users.update", bytes.NewBuffer(body), resp)
+	if err != nil {
+		return nil, err
+	}
+
+	updatedUser := &models.User{
+		ID:       resp.User.ID,
+		Name:     resp.User.Name,
+		UserName: resp.User.Username,
+		Status:   resp.User.Status,
+	}
+
+	return updatedUser, nil
 }
 
 // SetUserAvatar updates a user's avatar being logged in with a user that has permission to do so.
 // Currently only passing an URL is possible.
 //
 // https://rocket.chat/docs/developer-guides/rest-api/users/setavatar/
-func (c *Client) SetUserAvatar(userID, username, avatarURL string) (*Status, error) {
+func (c *Client) SetUserAvatar(userID, username, avatarURL string) error {
 	body := fmt.Sprintf(`{ "userId": "%s","username": "%s","avatarUrl":"%s"}`, userID, username, avatarURL)
 	response := new(Status)
-	err := c.Post("users.setAvatar", bytes.NewBufferString(body), response)
-	return response, err
+	return c.Post("users.setAvatar", bytes.NewBufferString(body), response)
 }
 
-func (c *Client) GetUserStatus(username string) (*UserStatusResponse, error) {
+func (c *Client) GetUserStatus(username string) (*models.UserStatus, error) {
 	params := url.Values{
 		"username": []string{username},
 	}
 
 	response := new(UserStatusResponse)
-	err := c.Get("users.getStatus", params, response)
-	return response, err
+	if err := c.Get("users.getStatus", params, response); err != nil {
+		return nil, err
+	}
+
+	userStatus := &models.UserStatus{
+		Message:          response.Message,
+		Status:           response.Status,
+		ConnectionStatus: response.ConnectionStatus,
+	}
+
+	return userStatus, nil
 }

--- a/rest/users.go
+++ b/rest/users.go
@@ -25,7 +25,7 @@ type logonResponse struct {
 	} `json:"data"`
 }
 
-type createUserRequest struct {
+type CreateUserRequest struct {
 	Name         string            `json:"name"`
 	Email        string            `json:"email"`
 	Password     string            `json:"password"`
@@ -59,7 +59,7 @@ type createUserResponse struct {
 	} `json:"user"`
 }
 
-type updateUserRequest struct {
+type UpdateUserRequest struct {
 	UserID string `json:"userId"`
 	Data   struct {
 		Name         string            `json:"name"`
@@ -151,7 +151,7 @@ func (c *Client) Logout() (string, error) {
 // CreateUser being logged in with a user that has permission to do so.
 //
 // https://rocket.chat/docs/developer-guides/rest-api/users/create
-func (c *Client) CreateUser(req *createUserRequest) (*models.User, error) {
+func (c *Client) CreateUser(req *CreateUserRequest) (*models.User, error) {
 	body, err := json.Marshal(req)
 	if err != nil {
 		return nil, err
@@ -175,7 +175,7 @@ func (c *Client) CreateUser(req *createUserRequest) (*models.User, error) {
 // UpdateUser updates a user's data being logged in with a user that has permission to do so.
 //
 // https://rocket.chat/docs/developer-guides/rest-api/users/update/
-func (c *Client) UpdateUser(req *updateUserRequest) (*models.User, error) {
+func (c *Client) UpdateUser(req *UpdateUserRequest) (*models.User, error) {
 	body, err := json.Marshal(req)
 	if err != nil {
 		return nil, err

--- a/rest/users.go
+++ b/rest/users.go
@@ -25,7 +25,16 @@ type logonResponse struct {
 	} `json:"data"`
 }
 
-type CreateUserResponse struct {
+type createUserRequest struct {
+	Name         string            `json:"name"`
+	Email        string            `json:"email"`
+	Password     string            `json:"password"`
+	Username     string            `json:"username"`
+	Roles        []string          `json:"roles,omitempty"`
+	CustomFields map[string]string `json:"customFields,omitempty"`
+}
+
+type createUserResponse struct {
 	Status
 	User struct {
 		ID        string    `json:"_id"`
@@ -50,14 +59,25 @@ type CreateUserResponse struct {
 	} `json:"user"`
 }
 
-type UserStatusResponse struct {
+type updateUserRequest struct {
+	UserID string `json:"userId"`
+	Data   struct {
+		Name         string            `json:"name"`
+		Email        string            `json:"email"`
+		Password     string            `json:"password"`
+		Username     string            `json:"username"`
+		CustomFields map[string]string `json:"customFields,omitempty"`
+	} `json:"data"`
+}
+
+type userStatusResponse struct {
 	models.UserStatus
 	ID      string `json:"_id"`
 	Error   string `json:"error"`
 	Success bool   `json:"success"`
 }
 
-func (s UserStatusResponse) OK() error {
+func (s userStatusResponse) OK() error {
 	if s.Success {
 		return nil
 	}
@@ -131,13 +151,13 @@ func (c *Client) Logout() (string, error) {
 // CreateUser being logged in with a user that has permission to do so.
 //
 // https://rocket.chat/docs/developer-guides/rest-api/users/create
-func (c *Client) CreateUser(req *models.CreateUserRequest) (*models.User, error) {
+func (c *Client) CreateUser(req *createUserRequest) (*models.User, error) {
 	body, err := json.Marshal(req)
 	if err != nil {
 		return nil, err
 	}
 
-	resp := new(CreateUserResponse)
+	resp := new(createUserResponse)
 	if err := c.Post("users.create", bytes.NewBuffer(body), resp); err != nil {
 		return nil, err
 	}
@@ -155,13 +175,13 @@ func (c *Client) CreateUser(req *models.CreateUserRequest) (*models.User, error)
 // UpdateUser updates a user's data being logged in with a user that has permission to do so.
 //
 // https://rocket.chat/docs/developer-guides/rest-api/users/update/
-func (c *Client) UpdateUser(req *models.UpdateUserRequest) (*models.User, error) {
+func (c *Client) UpdateUser(req *updateUserRequest) (*models.User, error) {
 	body, err := json.Marshal(req)
 	if err != nil {
 		return nil, err
 	}
 
-	resp := new(CreateUserResponse)
+	resp := new(createUserResponse)
 	err = c.Post("users.update", bytes.NewBuffer(body), resp)
 	if err != nil {
 		return nil, err
@@ -192,7 +212,7 @@ func (c *Client) GetUserStatus(username string) (*models.UserStatus, error) {
 		"username": []string{username},
 	}
 
-	response := new(UserStatusResponse)
+	response := new(userStatusResponse)
 	if err := c.Get("users.getStatus", params, response); err != nil {
 		return nil, err
 	}

--- a/rest/users_test.go
+++ b/rest/users_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/RocketChat/Rocket.Chat.Go.SDK/common_testing"
-	"github.com/RocketChat/Rocket.Chat.Go.SDK/models"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,16 +14,26 @@ func TestRocket_LoginLogout(t *testing.T) {
 }
 
 func TestRocket_CreateUser(t *testing.T) {
-	client := getDefaultClient(t)
+	rocket := getDefaultClient(t)
 
-	newUser := &models.CreateUserRequest{
+	newUser := &createUserRequest{
 		Name:     "Test User",
 		Email:    "testUser@test.com",
 		Password: "testPassword",
 		Username: "TestUser",
 	}
 
-	createdUser, err := client.CreateUser(newUser)
+	createdUser, err := rocket.CreateUser(newUser)
 	assert.Nil(t, err)
 	assert.NotNil(t, createdUser)
+}
+
+func TestRocket_GetUserStatus(t *testing.T) {
+	rocket := getDefaultClient(t)
+
+	status, err := rocket.GetUserStatus(testUserName)
+	assert.Nil(t, err)
+	assert.NotNil(t, status)
+	assert.Equal(t, "online", status.Status)
+	assert.Equal(t, "online", status.ConnectionStatus)
 }

--- a/rest/users_test.go
+++ b/rest/users_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/RocketChat/Rocket.Chat.Go.SDK/common_testing"
+	"github.com/RocketChat/Rocket.Chat.Go.SDK/models"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -11,8 +12,19 @@ func TestRocket_LoginLogout(t *testing.T) {
 	client := getAuthenticatedClient(t, common_testing.GetRandomString(), common_testing.GetRandomEmail(), common_testing.GetRandomString())
 	_, logoutErr := client.Logout()
 	assert.Nil(t, logoutErr)
+}
 
-	// channels, err := client.GetJoinedChannels()
-	// assert.Nil(t, channels)
-	// assert.NotNil(t, err)
+func TestRocket_CreateUser(t *testing.T) {
+	client := getDefaultClient(t)
+
+	newUser := &models.CreateUserRequest{
+		Name:     "Test User",
+		Email:    "testUser@test.com",
+		Password: "testPassword",
+		Username: "TestUser",
+	}
+
+	createdUser, err := client.CreateUser(newUser)
+	assert.Nil(t, err)
+	assert.NotNil(t, createdUser)
 }


### PR DESCRIPTION
This PR address #56 

In general, this PR modifies existing methods to return more concrete types in favor of response types. As a bi-product, a lot of the previously public response types have been made private. 

Other Changes:
- All response/request types were moved out of the `models` package and into respective files in the `rest` package
- Created types for `UserStatus` and `Room` in the `models` package
- Added additional tests for `im` and `users`

As some of these are backward incompatible changes, we might want to target a new release to encompass any other additional breaking changes. 