### PR TITLE
modified dm, group, channel history functions

### DIFF
--- a/rest/channels.go
+++ b/rest/channels.go
@@ -126,8 +126,9 @@ func (c *Client) ChannelHistory(channel *models.Channel, inclusive bool, fromDat
 		params.Add("count", strconv.Itoa(page.Count))
 	}
 
+	latestTime := fromDate.Format(time.RFC3339)
+	params.Add("latest", latestTime)
 	params.Add("inclusive", "true")
-	params.Add("oldest", fromDate.String())
 
 	response := new(MessagesResponse)
 	if err := c.Get("channels.history", params, response); err != nil {

--- a/rest/dm.go
+++ b/rest/dm.go
@@ -52,8 +52,9 @@ func (c *Client) DMHistory(channel *models.Channel, inclusive bool, fromDate tim
 		params.Add("count", strconv.Itoa(page.Count))
 	}
 
+	latestTime := fromDate.Format(time.RFC3339)
+	params.Add("latest", latestTime)
 	params.Add("inclusive", "true")
-	params.Add("oldest", fromDate.String())
 
 	response := new(MessagesResponse)
 	if err := c.Get("dm.history", params, response); err != nil {

--- a/rest/group.go
+++ b/rest/group.go
@@ -21,8 +21,9 @@ func (c *Client) GroupHistory(channel *models.Channel, inclusive bool, fromDate 
 		params.Add("count", strconv.Itoa(page.Count))
 	}
 
+	latestTime := fromDate.Format(time.RFC3339)
+	params.Add("latest", latestTime)
 	params.Add("inclusive", "true")
-	params.Add("oldest", fromDate.String())
 
 	response := new(MessagesResponse)
 	if err := c.Get("groups.history", params, response); err != nil {


### PR DESCRIPTION
latest param with correct time format need to passed as an argument so that it can be parsed correctly in the backend to fetch messages before the passed time